### PR TITLE
Add ability to link user account with existing account

### DIFF
--- a/kmpauth-firebase/api/kmpauth-firebase.api
+++ b/kmpauth-firebase/api/kmpauth-firebase.api
@@ -1,5 +1,6 @@
 public final class com/mmk/kmpauth/firebase/apple/AppleButtonUiContainerKt {
 	public static final fun AppleButtonUiContainer (Landroidx/compose/ui/Modifier;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AppleButtonUiContainer (Landroidx/compose/ui/Modifier;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class com/mmk/kmpauth/firebase/apple/AppleSignInRequestScope {
@@ -31,5 +32,6 @@ public final class com/mmk/kmpauth/firebase/google/GoogleButtonUiContainerFireba
 
 public final class com/mmk/kmpauth/firebase/oauth/OAuthContainer_androidKt {
 	public static final fun OAuthContainer (Landroidx/compose/ui/Modifier;Ldev/gitlive/firebase/auth/OAuthProvider;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun OAuthContainer (Landroidx/compose/ui/Modifier;Ldev/gitlive/firebase/auth/OAuthProvider;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -15,6 +15,7 @@ import dev.gitlive.firebase.auth.OAuthProvider
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
+ * @param linkAccount if true, it will link the account with the current user.
  * Example Usage:
  * ```
  * //Apple Sign-In with Custom Button and authentication with Firebase
@@ -30,6 +31,7 @@ public actual fun AppleButtonUiContainer(
     modifier: Modifier,
     requestScopes: List<AppleSignInRequestScope>,
     onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
     content: @Composable UiContainerScope.() -> Unit,
 ) {
     val oathProviderRequestScopes = requestScopes.map {
@@ -43,6 +45,7 @@ public actual fun AppleButtonUiContainer(
         modifier = modifier,
         oAuthProvider = oAuthProvider,
         onResult = onResult,
+        linkAccount = linkAccount,
         content = content
     )
 }

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -15,7 +15,7 @@ import dev.gitlive.firebase.auth.OAuthProvider
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
- * @param linkAccount if true, it will link the account with the current user.
+ * @param linkAccount if true, it will link the account with the current user. Default value is false
  * Example Usage:
  * ```
  * //Apple Sign-In with Custom Button and authentication with Firebase

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -51,8 +51,8 @@ public actual fun AppleButtonUiContainer(
 }
 
 @Deprecated(
-    "Use AppleButtonUiContainer with linkAccount parameter",
-    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    "Use AppleButtonUiContainer with the linkAccount parameter, which defaults to false.",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @Composable

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -49,3 +49,18 @@ public actual fun AppleButtonUiContainer(
         content = content
     )
 }
+
+@Deprecated(
+    "Use AppleButtonUiContainer with linkAccount parameter",
+    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+public actual fun AppleButtonUiContainer(
+    modifier: Modifier,
+    requestScopes: List<AppleSignInRequestScope>,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)
+}

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
@@ -36,6 +36,22 @@ public actual fun OAuthContainer(
     Box(modifier = modifier) { uiContainerScope.content() }
 }
 
+@Deprecated(
+    "Use OAuthContainer with linkAccount parameter",
+    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@OptIn(KMPAuthInternalApi::class)
+@Composable
+public actual fun OAuthContainer(
+    modifier: Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    OAuthContainer(modifier, oAuthProvider, onResult, false, content)
+}
+
 private fun onClickSignIn(
     activity: ComponentActivity?,
     oAuthProvider: OAuthProvider,

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
@@ -37,8 +37,8 @@ public actual fun OAuthContainer(
 }
 
 @Deprecated(
-    "Use OAuthContainer with linkAccount parameter",
-    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    "Use OAuthContainer with linkAccount parameter, which defaults to false",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @OptIn(KMPAuthInternalApi::class)

--- a/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
+++ b/kmpauth-firebase/src/androidMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.android.kt
@@ -47,9 +47,14 @@ private fun onClickSignIn(
     } else {
         if (activity == null)
             onResult(Result.failure(IllegalStateException("Activity is null")))
-        else
-            auth.startActivityForSignInWithProvider(activity, oAuthProvider.android)
-                .resultAsFirebaseUser(onResult)
+        else {
+            val currentUser = auth.currentUser
+            val result =
+                currentUser?.startActivityForLinkWithProvider(activity, oAuthProvider.android)
+                    ?: auth.startActivityForSignInWithProvider(activity, oAuthProvider.android)
+
+            result.resultAsFirebaseUser(onResult)
+        }
     }
 }
 

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -36,8 +36,8 @@ public expect fun AppleButtonUiContainer(
 )
 
 @Deprecated(
-    "Use AppleButtonUiContainer with linkAccount parameter",
-    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    "Use AppleButtonUiContainer with the linkAccount parameter, which defaults to false.",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @Composable

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -12,7 +12,7 @@ import dev.gitlive.firebase.auth.FirebaseUser
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
- * @param linkAccount boolean value to link account with existing account.
+ * @param linkAccount boolean value to link account with existing account. Default value is false
  * Example Usage:
  * ```
  * //Apple Sign-In with Custom Button and authentication with Firebase

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -34,3 +34,19 @@ public expect fun AppleButtonUiContainer(
     linkAccount: Boolean = false,
     content: @Composable UiContainerScope.() -> Unit,
 )
+
+@Deprecated(
+    "Use AppleButtonUiContainer with linkAccount parameter",
+    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+public expect fun AppleButtonUiContainer(
+    modifier: Modifier = Modifier,
+    requestScopes: List<AppleSignInRequestScope> = listOf(
+        AppleSignInRequestScope.FullName,
+        AppleSignInRequestScope.Email
+    ),
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+)

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -12,6 +12,7 @@ import dev.gitlive.firebase.auth.FirebaseUser
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
+ * @param linkAccount boolean value to link account with existing account.
  * Example Usage:
  * ```
  * //Apple Sign-In with Custom Button and authentication with Firebase
@@ -30,5 +31,6 @@ public expect fun AppleButtonUiContainer(
         AppleSignInRequestScope.Email
     ),
     onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean = false,
     content: @Composable UiContainerScope.() -> Unit,
 )

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/github/GithubButtonUiContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/github/GithubButtonUiContainer.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mmk.kmpauth.core.UiContainerScope
 import com.mmk.kmpauth.firebase.oauth.OAuthContainer
-import com.mmk.kmpauth.google.GoogleUser
 import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.OAuthProvider
 
@@ -16,6 +15,7 @@ import dev.gitlive.firebase.auth.OAuthProvider
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes Request Scopes that is provided in Github OAuth. By Default, user's email is requested.
  * @param customParameters Custom Parameters that is provided in Github OAuth.
+ * @param linkAccount [Boolean] flag to link account with current user. Default value is false.
  *
  * Example Usage:
  * ```
@@ -32,6 +32,7 @@ public fun GithubButtonUiContainer(
     modifier: Modifier = Modifier,
     requestScopes: List<String> = listOf("user:email"),
     customParameters: Map<String, String> = emptyMap(),
+    linkAccount: Boolean = false,
     onResult: (Result<FirebaseUser?>) -> Unit,
     content: @Composable UiContainerScope.() -> Unit,
 ) {
@@ -43,8 +44,33 @@ public fun GithubButtonUiContainer(
     OAuthContainer(
         modifier = modifier,
         oAuthProvider = oAuthProvider,
+        linkAccount = linkAccount,
         onResult = onResult,
         content = content
     )
 
+}
+
+
+@Deprecated(
+    "Use GithubButtonUiContainer with linkAccount parameter, which defaults to false",
+    ReplaceWith(""),
+    DeprecationLevel.WARNING
+)
+@Composable
+public fun GithubButtonUiContainer(
+    modifier: Modifier = Modifier,
+    requestScopes: List<String> = listOf("user:email"),
+    customParameters: Map<String, String> = emptyMap(),
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    GithubButtonUiContainer(
+        modifier = modifier,
+        requestScopes = requestScopes,
+        linkAccount = false,
+        customParameters = customParameters,
+        onResult = onResult,
+        content = content
+    )
 }

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/google/GoogleButtonUiContainerFirebase.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/google/GoogleButtonUiContainerFirebase.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 @Composable
 public fun GoogleButtonUiContainerFirebase(
     modifier: Modifier = Modifier,
+    linkAccount: Boolean = false,
     onResult: (Result<FirebaseUser?>) -> Unit,
     content: @Composable UiContainerScope.() -> Unit,
 ) {
@@ -50,7 +51,13 @@ public fun GoogleButtonUiContainerFirebase(
         val authCredential = GoogleAuthProvider.credential(idToken, accessToken)
         coroutineScope.launch {
             try {
-                val result = Firebase.auth.signInWithCredential(authCredential)
+                val auth = Firebase.auth
+                val currentUser = auth.currentUser
+                val result = if (linkAccount && currentUser != null) {
+                    currentUser.linkWithCredential(authCredential)
+                } else {
+                    auth.signInWithCredential(authCredential)
+                }
                 if (result.user == null) updatedOnResult(Result.failure(IllegalStateException("Firebase Null user")))
                 else updatedOnResult(Result.success(result.user))
             } catch (e: Exception) {
@@ -62,3 +69,23 @@ public fun GoogleButtonUiContainerFirebase(
     }, content = content)
 
 }
+
+@Deprecated(
+    "Use GoogleButtonUiContainerFirebase with linkAccount parameter, which defaults to false",
+    ReplaceWith(""),
+    DeprecationLevel.WARNING
+)
+@Composable
+public fun GoogleButtonUiContainerFirebase(
+    modifier: Modifier = Modifier,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    GoogleButtonUiContainerFirebase(
+        modifier = modifier,
+        linkAccount = false,
+        onResult = onResult,
+        content = content
+    )
+}
+

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
@@ -13,6 +13,7 @@ import dev.gitlive.firebase.auth.OAuthProvider
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param oAuthProvider [OAuthProvider] class object.
+ * @param linkAccount [Boolean] flag to link account with existing user.
  *
  * Example Usage:
  * ```
@@ -33,5 +34,6 @@ public expect fun OAuthContainer(
     modifier: Modifier = Modifier,
     oAuthProvider: OAuthProvider,
     onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean = false,
     content: @Composable UiContainerScope.() -> Unit,
 )

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
@@ -37,3 +37,16 @@ public expect fun OAuthContainer(
     linkAccount: Boolean = false,
     content: @Composable UiContainerScope.() -> Unit,
 )
+
+@Deprecated(
+    "Use OAuthContainer with linkAccount parameter",
+    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+public expect fun OAuthContainer(
+    modifier: Modifier = Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+)

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
@@ -13,7 +13,7 @@ import dev.gitlive.firebase.auth.OAuthProvider
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param oAuthProvider [OAuthProvider] class object.
- * @param linkAccount [Boolean] flag to link account with existing user.
+ * @param linkAccount [Boolean] flag to link account with current user. Default value is false.
  *
  * Example Usage:
  * ```

--- a/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
+++ b/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.kt
@@ -39,8 +39,8 @@ public expect fun OAuthContainer(
 )
 
 @Deprecated(
-    "Use OAuthContainer with linkAccount parameter",
-    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    "Use OAuthContainer with linkAccount parameter, which defaults to false",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @Composable

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -199,16 +199,28 @@ private class ASAuthorizationControllerDelegate(private val onResult: (Result<Fi
             idTokenString, currentNonce, appleIDCredential.fullName
         )
 
-        FIRAuth.auth().signInWithCredential(credential) { firAuthDataResult, nsError ->
-            if (nsError != null || firAuthDataResult == null) {
-                onResult(Result.failure(IllegalStateException(nsError?.localizedFailureReason)))
-                return@signInWithCredential
-            } else {
-                onResult(Result.success(Firebase.auth.currentUser))
-                return@signInWithCredential
+        val currentUser = FIRAuth.auth().currentUser
+        if (currentUser != null) {
+            currentUser.linkWithCredential(credential) { firAuthDataResult, nsError ->
+                if (nsError != null || firAuthDataResult == null) {
+                    onResult(Result.failure(IllegalStateException(nsError?.localizedFailureReason)))
+                    return@linkWithCredential
+                } else {
+                    onResult(Result.success(Firebase.auth.currentUser))
+                    return@linkWithCredential
+                }
+            }
+        } else {
+            FIRAuth.auth().signInWithCredential(credential) { firAuthDataResult, nsError ->
+                if (nsError != null || firAuthDataResult == null) {
+                    onResult(Result.failure(IllegalStateException(nsError?.localizedFailureReason)))
+                    return@signInWithCredential
+                } else {
+                    onResult(Result.success(Firebase.auth.currentUser))
+                    return@signInWithCredential
+                }
             }
         }
-
     }
 
     override fun authorizationController(

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -101,6 +101,21 @@ public actual fun AppleButtonUiContainer(
 
 }
 
+@Deprecated(
+    "Use AppleButtonUiContainer with linkAccount parameter",
+    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+public actual fun AppleButtonUiContainer(
+    modifier: Modifier,
+    requestScopes: List<AppleSignInRequestScope>,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)
+}
+
 private fun signIn(
     requestScopes: List<AppleSignInRequestScope>,
     authorizationController: ASAuthorizationControllerDelegate,

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -92,7 +92,6 @@ public actual fun AppleButtonUiContainer(
                     requestScopes = requestScopes,
                     authorizationController = asAuthorizationControllerDelegate,
                     presentationContextProvider = presentationContextProvider,
-                    linkAccount = linkAccount
                 )
             }
 
@@ -106,7 +105,6 @@ private fun signIn(
     requestScopes: List<AppleSignInRequestScope>,
     authorizationController: ASAuthorizationControllerDelegate,
     presentationContextProvider: PresentationContextProvider,
-    linkAccount: Boolean,
 ) {
     val appleIdProviderRequest = ASAuthorizationAppleIDProvider().createRequest()
     appleIdProviderRequest.requestedScopes = requestScopes.map {

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -62,6 +62,7 @@ private var currentNonce: String? = null
  *
  * [onResult] callback will return [Result] with [FirebaseUser] type.
  * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
+ * @param linkAccount if true, it will link the account with the current user. Default value is false
  * Example Usage:
  * ```
  * //Apple Sign-In with Custom Button and authentication with Firebase
@@ -91,7 +92,7 @@ public actual fun AppleButtonUiContainer(
                 signIn(
                     requestScopes = requestScopes,
                     authorizationController = asAuthorizationControllerDelegate,
-                    presentationContextProvider = presentationContextProvider,
+                    presentationContextProvider = presentationContextProvider
                 )
             }
 

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -102,8 +102,8 @@ public actual fun AppleButtonUiContainer(
 }
 
 @Deprecated(
-    "Use AppleButtonUiContainer with linkAccount parameter",
-    ReplaceWith("AppleButtonUiContainer(modifier, requestScopes, onResult, false, content)"),
+    "Use AppleButtonUiContainer with the linkAccount parameter, which defaults to false.",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @Composable

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.kt
@@ -220,7 +220,7 @@ private class ASAuthorizationControllerDelegate(
             idTokenString, currentNonce, appleIDCredential.fullName
         )
 
-        val currentUser = FIRAuth.auth().currentUser
+        val currentUser = FIRAuth.auth().currentUser()
 
         val handleResult: (FIRAuthDataResult?, NSError?) -> Unit = { firAuthDataResult, nsError ->
             if (nsError != null || firAuthDataResult == null) {

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import cocoapods.FirebaseAuth.FIRAuthCredential
+import cocoapods.FirebaseAuth.FIRAuthDataResult
 import com.mmk.kmpauth.core.UiContainerScope
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.AuthCredential
@@ -17,6 +18,7 @@ import dev.gitlive.firebase.auth.ios
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import platform.Foundation.NSError
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import dev.gitlive.firebase.auth.ios
@@ -30,6 +32,7 @@ public actual fun OAuthContainer(
     modifier: Modifier,
     oAuthProvider: OAuthProvider,
     onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
     content: @Composable UiContainerScope.() -> Unit,
 ) {
     val updatedOnResultFunc by rememberUpdatedState(onResult)
@@ -39,7 +42,7 @@ public actual fun OAuthContainer(
         object : UiContainerScope {
             override fun onClick() {
                 coroutineScope.launch {
-                    val result = onClickSignIn(oAuthProvider)
+                    val result = onClickSignIn(oAuthProvider, linkAccount)
                     mOnResult?.invoke(result)
                     mOnResult = null
                 }
@@ -53,15 +56,24 @@ public actual fun OAuthContainer(
 @OptIn(ExperimentalForeignApi::class)
 private suspend fun onClickSignIn(
     oAuthProvider: OAuthProvider,
+    linkAccount: Boolean,
 ): Result<FirebaseUser?> = suspendCoroutine { continuation ->
     oAuthProvider.ios.getCredentialWithUIDelegate(null,
         completion = { firAuthCredential, nsError ->
             if (firAuthCredential != null) {
                 val authCredential = firAuthCredential.asAuthCredential().ios
                 val auth = Firebase.auth.ios
-                auth.signInWithCredential(authCredential) { result, signInError ->
+                val currentUser = auth.currentUser
+
+                val handleResult: (FIRAuthDataResult?, NSError?) -> Unit = { result, linkError ->
                     if (result != null) continuation.resume(Result.success(Firebase.auth.currentUser))
-                    else continuation.resume(Result.failure(IllegalStateException(signInError?.localizedFailureReason)))
+                    else continuation.resume(Result.failure(IllegalStateException(linkError?.localizedFailureReason)))
+                }
+
+                if (linkAccount && currentUser != null) {
+                    currentUser.linkWithCredential(authCredential, handleResult)
+                } else {
+                    auth.signInWithCredential(authCredential, handleResult)
                 }
             } else
                 continuation.resume(Result.failure(IllegalStateException(nsError?.localizedFailureReason)))

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
@@ -53,6 +53,21 @@ public actual fun OAuthContainer(
     Box(modifier = modifier) { uiContainerScope.content() }
 }
 
+@Deprecated(
+    "Use OAuthContainer with linkAccount parameter",
+    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    DeprecationLevel.WARNING
+)
+@Composable
+public actual fun OAuthContainer(
+    modifier: Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+    OAuthContainer(modifier, oAuthProvider, onResult, false, content)
+}
+
 @OptIn(ExperimentalForeignApi::class)
 private suspend fun onClickSignIn(
     oAuthProvider: OAuthProvider,

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
@@ -54,8 +54,8 @@ public actual fun OAuthContainer(
 }
 
 @Deprecated(
-    "Use OAuthContainer with linkAccount parameter",
-    ReplaceWith("OAuthContainer(modifier, oAuthProvider, onResult, false, content)"),
+    "Use OAuthContainer with linkAccount parameter, which defaults to false",
+    ReplaceWith(""),
     DeprecationLevel.WARNING
 )
 @Composable

--- a/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
+++ b/kmpauth-firebase/src/iosMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.ios.kt
@@ -78,7 +78,7 @@ private suspend fun onClickSignIn(
             if (firAuthCredential != null) {
                 val authCredential = firAuthCredential.asAuthCredential().ios
                 val auth = Firebase.auth.ios
-                val currentUser = auth.currentUser
+                val currentUser = auth.currentUser()
 
                 val handleResult: (FIRAuthDataResult?, NSError?) -> Unit = { result, linkError ->
                     if (result != null) continuation.resume(Result.success(Firebase.auth.currentUser))

--- a/kmpauth-firebase/src/jsMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.js.kt
+++ b/kmpauth-firebase/src/jsMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.js.kt
@@ -30,3 +30,14 @@ public actual fun AppleButtonUiContainer(
     content: @Composable UiContainerScope.() -> Unit
 ) {
 }
+
+@Composable
+public actual fun AppleButtonUiContainer(
+    modifier: Modifier,
+    requestScopes: List<AppleSignInRequestScope>,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
+    content: @Composable UiContainerScope.() -> Unit,
+){
+
+}

--- a/kmpauth-firebase/src/jsMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.js.kt
+++ b/kmpauth-firebase/src/jsMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.js.kt
@@ -36,3 +36,14 @@ public actual fun OAuthContainer(
     content: @Composable UiContainerScope.() -> Unit
 ) {
 }
+
+@Composable
+public actual fun OAuthContainer(
+    modifier: Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+
+}

--- a/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.jvm.kt
+++ b/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.jvm.kt
@@ -30,3 +30,14 @@ public actual fun AppleButtonUiContainer(
     content: @Composable UiContainerScope.() -> Unit
 ) {
 }
+
+@Composable
+public actual fun AppleButtonUiContainer(
+    modifier: Modifier,
+    requestScopes: List<AppleSignInRequestScope>,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+
+}

--- a/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.jvm.kt
+++ b/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.jvm.kt
@@ -36,3 +36,14 @@ public actual fun OAuthContainer(
     content: @Composable UiContainerScope.() -> Unit
 ) {
 }
+
+@Composable
+public actual fun OAuthContainer(
+    modifier: Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    linkAccount: Boolean,
+    content: @Composable UiContainerScope.() -> Unit,
+) {
+
+}

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
@@ -75,7 +75,7 @@ fun App() {
             }
 
             //Github Sign-In with Custom Button and authentication with Firebase
-            GithubButtonUiContainer(onResult = onFirebaseResult) {
+            GithubButtonUiContainer(onResult = onFirebaseResult, linkAccount = false) {
                 Button(onClick = { this.onClick() }) { Text("Github Sign-In (Custom Design)") }
             }
 

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
@@ -109,7 +109,7 @@ fun AuthUiHelperButtonsAndFirebaseAuth(
     ) {
 
         //Google Sign-In Button and authentication with Firebase
-        GoogleButtonUiContainerFirebase(onResult = onFirebaseResult) {
+        GoogleButtonUiContainerFirebase(onResult = onFirebaseResult, linkAccount = false) {
             GoogleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp), fontSize = 19.sp) { this.onClick() }
         }
 
@@ -132,7 +132,7 @@ fun IconOnlyButtonsAndFirebaseAuth(
     ) {
 
         //Google Sign-In IconOnly Button and authentication with Firebase
-        GoogleButtonUiContainerFirebase(onResult = onFirebaseResult) {
+        GoogleButtonUiContainerFirebase(onResult = onFirebaseResult, linkAccount = false) {
             GoogleSignInButtonIconOnly(onClick = { this.onClick() })
         }
 

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/mmk/kmpauth/sample/App.kt
@@ -70,7 +70,7 @@ fun App() {
             }
 
             //Apple Sign-In with Custom Button and authentication with Firebase
-            AppleButtonUiContainer(onResult = onFirebaseResult) {
+            AppleButtonUiContainer(onResult = onFirebaseResult, linkAccount = false) {
                 Button(onClick = { this.onClick() }) { Text("Apple Sign-In (Custom Design)") }
             }
 
@@ -114,7 +114,7 @@ fun AuthUiHelperButtonsAndFirebaseAuth(
         }
 
         //Apple Sign-In Button and authentication with Firebase
-        AppleButtonUiContainer(onResult = onFirebaseResult) {
+        AppleButtonUiContainer(onResult = onFirebaseResult, linkAccount = false) {
             AppleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp)) { this.onClick() }
         }
 
@@ -137,7 +137,7 @@ fun IconOnlyButtonsAndFirebaseAuth(
         }
 
         //Apple Sign-In IconOnly Button and authentication with Firebase
-        AppleButtonUiContainer(onResult = onFirebaseResult) {
+        AppleButtonUiContainer(onResult = onFirebaseResult, linkAccount = false) {
             AppleSignInButtonIconOnly(onClick = { this.onClick() })
         }
     }


### PR DESCRIPTION
This PR allows Firebase accounts to be linked. The feature is toggleable because Apple requires getting explicit permission when linking Apple accounts to other accounts.