### PR TITLE
Desktop support (only target with dummy class and methods)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidxCredential = "1.3.0-rc01"
 googleIdIdentity = "1.1.1"
 koinCompose = "4.0.0-RC1"
 googleServices = "4.4.2"
-firebaseGitLiveAuth = "1.12.0"
+firebaseGitLiveAuth = "1.13.0"
 androidLegacyPlayServices = "21.2.0"
 nexusPublish = "2.0.0"
 

--- a/kmpauth-core/build.gradle.kts
+++ b/kmpauth-core/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         }
     }
 
-
+    jvm()
     iosX64()
     iosArm64()
     iosSimulatorArm64()

--- a/kmpauth-core/src/jvmMain/kotlin/com/mmk/kmpauth/core/di/PlatformModule.jvm.kt
+++ b/kmpauth-core/src/jvmMain/kotlin/com/mmk/kmpauth/core/di/PlatformModule.jvm.kt
@@ -1,0 +1,9 @@
+package com.mmk.kmpauth.core.di
+
+import com.mmk.kmpauth.core.KMPAuthInternalApi
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+@KMPAuthInternalApi
+public actual fun isAndroidPlatform(): Boolean = false
+internal actual val platformModule: Module = module { }

--- a/kmpauth-firebase/build.gradle.kts
+++ b/kmpauth-firebase/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
             }
         }
     }
-
+    jvm()
 
     iosX64()
     iosArm64()

--- a/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.jvm.kt
+++ b/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/apple/AppleButtonUiContainer.jvm.kt
@@ -1,0 +1,32 @@
+package com.mmk.kmpauth.firebase.apple
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mmk.kmpauth.core.UiContainerScope
+import dev.gitlive.firebase.auth.FirebaseUser
+
+/**
+ * AppleButton Ui Container Composable that handles all sign-in functionality for Apple.
+ * Child of this Composable can be any view or Composable function.
+ * You need to call [UiContainerScope.onClick] function on your child view's click function.
+ *
+ * [onResult] callback will return [Result] with [FirebaseUser] type.
+ * @param requestScopes list of request scopes type of [AppleSignInRequestScope].
+ * Example Usage:
+ * ```
+ * //Apple Sign-In with Custom Button and authentication with Firebase
+ * AppleButtonUiContainer(onResult = onFirebaseResult) {
+ *     Button(onClick = { this.onClick() }) { Text("Apple Sign-In (Custom Design)") }
+ * }
+ *
+ * ```
+ *
+ */
+@Composable
+public actual fun AppleButtonUiContainer(
+    modifier: Modifier,
+    requestScopes: List<AppleSignInRequestScope>,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit
+) {
+}

--- a/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.jvm.kt
+++ b/kmpauth-firebase/src/jvmMain/kotlin/com/mmk/kmpauth/firebase/oauth/OAuthContainer.jvm.kt
@@ -1,0 +1,38 @@
+package com.mmk.kmpauth.firebase.oauth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mmk.kmpauth.core.UiContainerScope
+import dev.gitlive.firebase.auth.FirebaseUser
+import dev.gitlive.firebase.auth.OAuthProvider
+
+/**
+ * OAuth Ui Container Composable that handles all sign-in functionality for given provider.
+ * Child of this Composable can be any view or Composable function.
+ * You need to call [UiContainerScope.onClick] function on your child view's click function.
+ *
+ * [onResult] callback will return [Result] with [FirebaseUser] type.
+ * @param oAuthProvider [OAuthProvider] class object.
+ *
+ * Example Usage:
+ * ```
+ *
+ * OAuthContainer(onResult = onFirebaseResult) {
+ *     Button(onClick = { this.onClick() }) { Text("Github Sign-In (Custom Design)") }
+ * }
+ * val oAuthProvider = OAuthProvider(provider = "github.com")
+ * OAuthContainer(modifier = modifier, oAuthProvider = oAuthProvider,onResult = onFirebaseResult){
+ *  Button(onClick = { this.onClick() }) { Text("Github Sign-In (Custom Design)") }
+ * }
+ *
+ * ```
+ *
+ */
+@Composable
+public actual fun OAuthContainer(
+    modifier: Modifier,
+    oAuthProvider: OAuthProvider,
+    onResult: (Result<FirebaseUser?>) -> Unit,
+    content: @Composable UiContainerScope.() -> Unit
+) {
+}

--- a/kmpauth-google/build.gradle.kts
+++ b/kmpauth-google/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
             }
         }
     }
-
+    jvm()
 
     iosX64()
     iosArm64()

--- a/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthProviderImpl.kt
+++ b/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthProviderImpl.kt
@@ -1,0 +1,15 @@
+package com.mmk.kmpauth.google
+
+import androidx.compose.runtime.Composable
+
+internal class GoogleAuthProviderImpl : GoogleAuthProvider {
+
+    @Composable
+    override fun getUiProvider(): GoogleAuthUiProvider {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun signOut() {
+        TODO("Not yet implemented")
+    }
+}

--- a/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -1,0 +1,8 @@
+package com.mmk.kmpauth.google
+
+internal class GoogleAuthUiProviderImpl : GoogleAuthUiProvider {
+    override suspend fun signIn(): GoogleUser? {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/di/GoogleAuthModule.jvm.kt
+++ b/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/di/GoogleAuthModule.jvm.kt
@@ -1,0 +1,12 @@
+package com.mmk.kmpauth.google.di
+
+import com.mmk.kmpauth.google.GoogleAuthProvider
+import com.mmk.kmpauth.google.GoogleAuthProviderImpl
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val googleAuthPlatformModule: Module = module {
+    factoryOf(::GoogleAuthProviderImpl) bind GoogleAuthProvider::class
+}

--- a/kmpauth-uihelper/build.gradle.kts
+++ b/kmpauth-uihelper/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
             }
         }
     }
+    jvm()
 
 
     iosX64()

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -17,6 +18,7 @@ kotlin {
             }
         }
     }
+    jvm("desktop")
     listOf(
         iosX64(),
         iosArm64(),
@@ -28,6 +30,7 @@ kotlin {
         }
     }
     sourceSets {
+        val desktopMain by getting
 
         androidMain.dependencies {
             implementation(libs.compose.ui)
@@ -43,6 +46,9 @@ kotlin {
             implementation(project(":kmpauth-google"))
             implementation(project(":kmpauth-firebase"))
             implementation(project(":kmpauth-uihelper"))
+        }
+        desktopMain.dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }
@@ -81,6 +87,18 @@ android {
     }
     dependencies {
         debugImplementation(libs.compose.ui.tooling)
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "com.mmk.kmpauthdesktop"
+            packageVersion = "1.0.0"
+        }
     }
 }
 

--- a/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Main.kt
+++ b/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Main.kt
@@ -25,8 +25,7 @@ fun main() = application {
         title = "KMPAuth Desktop",
     ) {
         println("Desktop app is started")
-
-        //Google Sign-In Button and authentication with Firebase
+//        App()
         Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             GoogleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp), fontSize = 19.sp) {  }
             AppleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp)) { }

--- a/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Main.kt
+++ b/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Main.kt
@@ -1,0 +1,39 @@
+package com.mmk.kmpauth.sample
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.mmk.kmpauth.firebase.apple.AppleButtonUiContainer
+import com.mmk.kmpauth.firebase.google.GoogleButtonUiContainerFirebase
+import com.mmk.kmpauth.uihelper.apple.AppleSignInButton
+import com.mmk.kmpauth.uihelper.apple.AppleSignInButtonIconOnly
+import com.mmk.kmpauth.uihelper.google.GoogleSignInButton
+import com.mmk.kmpauth.uihelper.google.GoogleSignInButtonIconOnly
+
+fun main() = application {
+    AppInitializer.onApplicationStart()
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "KMPAuth Desktop",
+    ) {
+        println("Desktop app is started")
+
+        //Google Sign-In Button and authentication with Firebase
+        Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            GoogleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp), fontSize = 19.sp) {  }
+            AppleSignInButton(modifier = Modifier.fillMaxWidth().height(44.dp)) { }
+
+            GoogleSignInButtonIconOnly(onClick = {  })
+            AppleSignInButtonIconOnly(onClick = { })
+        }
+
+    }
+}

--- a/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Platform.desktop.kt
+++ b/sampleApp/composeApp/src/desktopMain/kotlin/com/mmk/kmpauth/sample/Platform.desktop.kt
@@ -1,0 +1,4 @@
+package com.mmk.kmpauth.sample
+
+actual fun onApplicationStartPlatformSpecific() {
+}


### PR DESCRIPTION
For now desktop target is added only in order to call kmpauth methods from common source set. Implementation details will be added later