### PR TITLE
Add email to GoogleUser

### DIFF
--- a/kmpauth-google/api/android/kmpauth-google.api
+++ b/kmpauth-google/api/android/kmpauth-google.api
@@ -35,17 +35,19 @@ public final class com/mmk/kmpauth/google/GoogleButtonUiContainerKt {
 
 public final class com/mmk/kmpauth/google/GoogleUser {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleUser;
-	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleUser;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleUser;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleUser;
+	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleUser;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccessToken ()Ljava/lang/String;
 	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
 	public final fun getIdToken ()Ljava/lang/String;
 	public final fun getProfilePicUrl ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/kmpauth-google/api/jvm/kmpauth-google.api
+++ b/kmpauth-google/api/jvm/kmpauth-google.api
@@ -35,17 +35,19 @@ public final class com/mmk/kmpauth/google/GoogleButtonUiContainerKt {
 
 public final class com/mmk/kmpauth/google/GoogleUser {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleUser;
-	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleUser;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleUser;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleUser;
+	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleUser;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccessToken ()Ljava/lang/String;
 	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
 	public final fun getIdToken ()Ljava/lang/String;
 	public final fun getProfilePicUrl ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/kmpauth-google/src/androidMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/kmpauth-google/src/androidMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -73,6 +73,7 @@ internal class GoogleAuthUiProviderImpl(
                     GoogleUser(
                         idToken = googleIdTokenCredential.idToken,
                         accessToken = null,
+                        email = googleIdTokenCredential.id,
                         displayName = googleIdTokenCredential.displayName ?: "",
                         profilePicUrl = googleIdTokenCredential.profilePictureUri?.toString()
                     )

--- a/kmpauth-google/src/androidMain/kotlin/com/mmk/kmpauth/google/GoogleLegacyAuthentication.kt
+++ b/kmpauth-google/src/androidMain/kotlin/com/mmk/kmpauth/google/GoogleLegacyAuthentication.kt
@@ -52,6 +52,7 @@ internal class GoogleLegacyAuthentication(
                 GoogleUser(
                     idToken = idToken,
                     accessToken = null,
+                    email = account.email,
                     displayName = account.displayName ?: "",
                     profilePicUrl = account.photoUrl?.toString()
                 ).also {

--- a/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleUser.kt
+++ b/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleUser.kt
@@ -5,7 +5,8 @@ package com.mmk.kmpauth.google
  */
 public data class GoogleUser(
     val idToken: String,
-    val accessToken:String?=null,
+    val accessToken:String? = null,
+    val email: String? = null,
     val displayName: String = "",
     val profilePicUrl: String? = null,
 )

--- a/kmpauth-google/src/iosMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/kmpauth-google/src/iosMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -27,6 +27,7 @@ internal class GoogleAuthUiProviderImpl : GoogleAuthUiProvider {
                         val googleUser = GoogleUser(
                             idToken = idToken,
                             accessToken = accessToken,
+                            email = user?.userID,
                             displayName = profile?.name ?: "",
                             profilePicUrl = profile?.imageURLWithDimension(320u)?.absoluteString
                         )

--- a/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -54,6 +54,7 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             return null
         }
         val jwt = JWT().decodeJwt(idToken)
+        val email = jwt.getClaim("email")?.asString()
         val name = jwt.getClaim("name")?.asString() // User's name
         val picture = jwt.getClaim("picture")?.asString()
         val receivedNonce = jwt.getClaim("nonce")?.asString()
@@ -65,6 +66,7 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         return GoogleUser(
             idToken = idToken,
             accessToken = null,
+            email = email,
             displayName = name ?: "",
             profilePicUrl = picture
         )


### PR DESCRIPTION
Is it ok to retrieve email directly from idToken on client device? 
As pointed out in [this issue](https://github.com/mirzemehdi/KMPAuth/issues/52) email is sometimes omitted from idToken but it seems it is mandatory field in GoogleIdTokenCredential so we can get it from there