### PR TITLE
Add missing dependency on `kmpauth-core` to `kmpauth-firebase`

### DIFF
--- a/kmpauth-firebase/build.gradle.kts
+++ b/kmpauth-firebase/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
             implementation(compose.material)
             implementation(libs.koin.compose)
             api(libs.firebase.gitlive.auth)
+            api(project(":kmpauth-core"))
             implementation(project(":kmpauth-google"))
         }
     }


### PR DESCRIPTION
The `UiContainerScope` from `kmpauth-core` is contained in the libraries public API as argument on `GoogleButtonUiContainerFirebase`: https://github.com/mirzemehdi/KMPAuth/blob/main/kmpauth-firebase/src/commonMain/kotlin/com/mmk/kmpauth/firebase/google/GoogleButtonUiContainerFirebase.kt#L44