### PR TITLE
Fix Android artifact publishing

### DIFF
--- a/kmpauth-core/build.gradle.kts
+++ b/kmpauth-core/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 kotlin {
     explicitApi()
     androidTarget {
-        publishLibraryVariants()
+        publishLibraryVariants("release")
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }

--- a/kmpauth-firebase/build.gradle.kts
+++ b/kmpauth-firebase/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 kotlin {
     explicitApi()
     androidTarget {
-        publishLibraryVariants()
+        publishLibraryVariants("release")
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }

--- a/kmpauth-google/build.gradle.kts
+++ b/kmpauth-google/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 kotlin {
     explicitApi()
     androidTarget {
-        publishLibraryVariants()
+        publishLibraryVariants("release")
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }

--- a/kmpauth-uihelper/build.gradle.kts
+++ b/kmpauth-uihelper/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 kotlin {
     explicitApi()
     androidTarget {
-        publishLibraryVariants()
+        publishLibraryVariants("release")
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
         }


### PR DESCRIPTION
In #139 the deprecated `publishAllLibraryVariants()` was replaced with `publishLibraryVariants()`, but no variants were specified.

This PR adds the `"release"` variant, if you want the debug variant too, it can be added 👍 .

Should resolve #149 