### PR TITLE
feat: Add custom redirect URI support for Google Sign-In on JVM/Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,58 @@ Create GoogleAuthProvider instance by providing _**Web Client Id**_ as a serverI
 GoogleAuthProvider.create(credentials = GoogleAuthCredentials(serverId = WebClientId))
 
 ```
+
+For **JVM/Desktop** platform, you can optionally specify a custom `redirectUri`:
+```kotlin
+GoogleAuthProvider.create(
+    credentials = GoogleAuthCredentials(
+        serverId = WebClientId,
+        redirectUri = "http://localhost:8080/callback" // Optional, defaults to http://localhost:8080/callback
+    )
+)
+```
+**Important:** Make sure the `redirectUri` you specify is registered as an authorized redirect URI in your Google Cloud Console OAuth 2.0 credentials.
+
 <details>
   <summary>Android</summary>
 
 ##### Android Setup
 There is not any platform specific setup in Android side.
+
+</details>
+
+<details>
+  <summary>JVM/Desktop</summary>
+
+##### JVM/Desktop Setup
+For JVM/Desktop applications, the library starts a local HTTP server to handle the OAuth callback. 
+
+**Default Behavior:**
+- The library tries to use port 8080 first
+- If port 8080 is occupied, it tries ports 8081-8089
+- The default redirect URI is `http://localhost:8080/callback`
+
+**Custom Redirect URI:**
+You can specify a custom redirect URI when creating the GoogleAuthProvider:
+```kotlin
+GoogleAuthProvider.create(
+    credentials = GoogleAuthCredentials(
+        serverId = "YOUR_WEB_CLIENT_ID",
+        redirectUri = "http://localhost:9090/callback" // Custom port
+    )
+)
+```
+
+**Google Cloud Console Setup:**
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Select your project
+3. Go to APIs & Services > Credentials
+4. Edit your OAuth 2.0 Client ID
+5. Add your redirect URI(s) to "Authorized redirect URIs":
+   - `http://localhost:8080/callback` (default)
+   - `http://localhost:8081/callback` (fallback)
+   - `http://localhost:8082/callback` (fallback)
+   - ... or your custom redirect URI
 
 </details>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ kotlin.mpp.enableCInteropCommonization=true
 #Development
 development=true
 
-kmpAuthVersion=2.5.0-alpha01
+kmpAuthVersion=2.5.0-alpha02

--- a/kmpauth-facebook/kmpauth_facebook.podspec
+++ b/kmpauth-facebook/kmpauth_facebook.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmpauth_facebook'
-    spec.version                  = '2.5.0-alpha01'
+    spec.version                  = '2.5.0-alpha02'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/kmpauth-firebase-facebook/kmpauth_firebase_facebook.podspec
+++ b/kmpauth-firebase-facebook/kmpauth_firebase_facebook.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmpauth_firebase_facebook'
-    spec.version                  = '2.5.0-alpha01'
+    spec.version                  = '2.5.0-alpha02'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/kmpauth-firebase/kmpauth_firebase.podspec
+++ b/kmpauth-firebase/kmpauth_firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmpauth_firebase'
-    spec.version                  = '2.5.0-alpha01'
+    spec.version                  = '2.5.0-alpha02'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/kmpauth-google/kmpauth_google.podspec
+++ b/kmpauth-google/kmpauth_google.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmpauth_google'
-    spec.version                  = '2.5.0-alpha01'
+    spec.version                  = '2.5.0-alpha02'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthCredentials.kt
+++ b/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthCredentials.kt
@@ -3,5 +3,11 @@ package com.mmk.kmpauth.google
 /**
  * Google Auth Credentials holder class.
  * @param serverId - This should be Web Client Id that you created in Google OAuth page
+ * @param redirectUri - (JVM only) Custom redirect URI for OAuth callback.
+ *                      If not provided, defaults to "http://localhost:8080/callback".
+ *                      Make sure this URI is registered in Google Cloud Console.
  */
-public data class GoogleAuthCredentials(val serverId: String)
+public data class GoogleAuthCredentials(
+    val serverId: String,
+    val redirectUri: String? = null
+)

--- a/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -10,7 +10,6 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
-import io.ktor.utils.io.core.use
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -25,13 +24,11 @@ import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.util.Base64
 
-
-private var foundAvailablePort: Int = 8080 //TODO temporary solution. Fix later in signin by passing redirect url
-
 internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCredentials) :
     GoogleAuthUiProvider {
 
     private val authUrl = "https://accounts.google.com/o/oauth2/v2/auth"
+    private val preferredPort: Int = 8080
 
     @OptIn(KMPAuthInternalApi::class)
     override suspend fun signIn(
@@ -39,9 +36,25 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         isAutoSelectEnabled: Boolean,
         scopes: List<String>
     ): GoogleUser? {
+        // Parse custom redirectUri or use default with preferred port
+        val (redirectUri, port) = if (credentials.redirectUri != null) {
+            // Use custom redirectUri and extract port from it
+            val customUri = credentials.redirectUri
+            val portFromUri = try {
+                URI(customUri).port.takeIf { it > 0 } ?: 8080
+            } catch (e: Exception) {
+                currentLogger.log("GoogleAuthUiProvider: Failed to parse redirectUri, using default port 8080")
+                8080
+            }
+            customUri to portFromUri
+        } else {
+            // Use default behavior: try preferred port, fallback to nearby ports
+            val foundPort = findAvailablePort(preferredPort)
+            "http://localhost:$foundPort/callback" to foundPort
+        }
+
         val responseType = "id_token token"
         val scopeString = scopes.joinToString(" ")
-        val redirectUri = "http://localhost:$foundAvailablePort/callback"
         val state: String
         var nonce: String?
         val googleAuthUrl = withContext(Dispatchers.IO) {
@@ -59,10 +72,12 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
                     "&state=$state"
         }
 
-
-        openUrlInBrowser(googleAuthUrl)
-
-        val (idToken, accessToken) = startHttpServerAndGetToken(state = state)
+        // Start server BEFORE opening browser
+        val (idToken, accessToken) = startHttpServerAndGetToken(
+            state = state,
+            googleAuthUrl = googleAuthUrl,
+            port = port
+        )
         if (idToken == null && accessToken == null) {
             currentLogger.log("GoogleAuthUiProvider: token is null")
             return null
@@ -91,7 +106,9 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
     //Pair, first one is idToken, second one is accessToken
     private suspend fun startHttpServerAndGetToken(
         redirectUriPath: String = "/callback",
-        state: String
+        state: String,
+        googleAuthUrl: String,
+        port: Int
     ): Pair<String?, String?> {
         val tokenPairDeferred = CompletableDeferred<Pair<String?, String?>>()
 
@@ -114,8 +131,8 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
                 }
             }                 
         """.trimIndent()
-        foundAvailablePort = findAvailablePort()
-        val server = embeddedServer(Netty, port = foundAvailablePort) {
+
+        val server = embeddedServer(Netty, port = port) {
             routing {
                 get(redirectUriPath) {
                     call.respondHtml {
@@ -142,6 +159,9 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             }
         }.start(wait = false)
 
+        // Open browser AFTER server is started
+        openUrlInBrowser(googleAuthUrl)
+
         val idTokenAndAccessTokenPair = tokenPairDeferred.await()
         server.stop(1000, 1000)
         return idTokenAndAccessTokenPair
@@ -164,8 +184,29 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
     }
 
 
-    private fun findAvailablePort(): Int {
+    @OptIn(KMPAuthInternalApi::class)
+    private fun findAvailablePort(preferredPort: Int = 8080): Int {
+        // First, try the preferred port
+        try {
+            ServerSocket(preferredPort).use {
+                return preferredPort
+            }
+        } catch (_: Exception) {
+            // Port is occupied, try nearby ports (8080-8089)
+            for (port in (preferredPort + 1)..(preferredPort + 9)) {
+                try {
+                    ServerSocket(port).use {
+                        currentLogger.log("GoogleAuthUiProvider: Preferred port $preferredPort is occupied, using port $port instead")
+                        return port
+                    }
+                } catch (_: Exception) {
+                    // Try next port
+                }
+            }
+        }
+        // If all preferred ports are occupied, find any available port
         val port = ServerSocket(0).use { socket -> socket.localPort }
+        currentLogger.log("GoogleAuthUiProvider: All preferred ports (8080-8089) are occupied, using random port $port. Make sure this is configured in Google Console.")
         return port
     }
 


### PR DESCRIPTION
### Overview
This PR improves the JVM/Desktop Google OAuth flow by allowing users to specify a custom `redirectUri` and fixing a race condition in the server startup sequence.

### Changes

#### `GoogleAuthCredentials`
- Added optional `redirectUri: String?` parameter (defaults to `null`)
- When provided, this URI is used as the OAuth callback endpoint on JVM/Desktop
- Must be registered as an authorized redirect URI in Google Cloud Console

#### `GoogleAuthUiProviderImpl` (JVM)
- Removed the global mutable `foundAvailablePort` variable in favor of a local, scoped approach
- When a custom `redirectUri` is provided, the port is extracted directly from the URI
- When no custom URI is provided, the default behavior tries port `8080` first, then falls back to `8081–8089`, and finally uses a random available port
- **Fixed race condition:** the local HTTP server is now started *before* opening the browser, ensuring the callback endpoint is ready to receive the OAuth response
- `startHttpServerAndGetToken` now receives `googleAuthUrl` and `port` as explicit parameters, removing hidden side effects

#### Documentation
- Updated `README.md` with a dedicated **JVM/Desktop Setup** section explaining default port behavior, custom redirect URI usage, and Google Cloud Console configuration steps

### Version
- Bumped version from `2.5.0-alpha01` → `2.5.0-alpha02`

### Issue that has been fixed
https://github.com/mirzemehdi/KMPAuth/issues/172

### Issues Found

During development, I noticed that the `firebase-java-sdk` from [GitLive](https://github.com/gitlive/firebase-kotlin-sdk) does not have its JVM implementation created — the JVM code essentially counts as a stub/TODO. The workaround found was to use the Firebase Identity Toolkit REST API directly to sign in with the Google credential:
POST: https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={firebaseApiKey}