### PR TITLE
test: characterization tests for core and google public contracts (PR-01)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '**/README.md'
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "rel_3.0.0" ]
 
 
 
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         config: [
-          { target: android, os: ubuntu-latest, tasks: testDebugUnitTest testReleaseUnitTest, continueOnError: false },
+          { target: android, os: ubuntu-latest, tasks: testDebugUnitTest testReleaseUnitTest jvmTest, continueOnError: false },
           { target: apple, os: macos-latest, tasks: iosSimulatorArm64Test, continueOnError: false },
         ]
     runs-on: ${{ matrix.config.os }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,10 +28,12 @@ androidLegacyPlayServices = "21.4.0"
 mavenPublish = "0.35.0"
 ktor = "3.3.3"
 kotlinx-serialization = "1.9.0"
+kotlinx-coroutines = "1.10.2"
 
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }

--- a/kmpauth-core/build.gradle.kts
+++ b/kmpauth-core/build.gradle.kts
@@ -72,6 +72,11 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
         }
 
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+
     }
 }
 

--- a/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/HttpClientFactoryTest.kt
+++ b/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/HttpClientFactoryTest.kt
@@ -1,0 +1,28 @@
+package com.mmk.kmpauth.core
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+
+/**
+ * Characterization tests for the internal HTTP client factory: every call
+ * produces a new, ready-to-use client (factory semantics, no caching).
+ */
+class HttpClientFactoryTest {
+
+    @Test
+    fun defaultReturnsUsableClient() {
+        val client = HttpClientFactory.default()
+        assertNotNull(client)
+        client.close()
+    }
+
+    @Test
+    fun defaultReturnsNewInstancePerCall() {
+        val first = HttpClientFactory.default()
+        val second = HttpClientFactory.default()
+        assertNotSame(first, second)
+        first.close()
+        second.close()
+    }
+}

--- a/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/LoggerContractTest.kt
+++ b/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/LoggerContractTest.kt
@@ -1,0 +1,53 @@
+package com.mmk.kmpauth.core
+
+import com.mmk.kmpauth.core.logger.KMPAuthLogger
+import com.mmk.kmpauth.core.logger.currentLogger
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Characterization tests locking the 2.x logging contract:
+ * [KMPAuth.setLogger] replaces the library-wide logger, and the logger
+ * receives messages verbatim (including null).
+ */
+@OptIn(KMPAuthInternalApi::class)
+class LoggerContractTest {
+
+    private lateinit var loggerBefore: KMPAuthLogger
+
+    @BeforeTest
+    fun saveLogger() {
+        loggerBefore = currentLogger
+    }
+
+    @AfterTest
+    fun restoreLogger() {
+        currentLogger = loggerBefore
+    }
+
+    @Test
+    fun setLoggerRoutesMessagesToProvidedLogger() {
+        val received = mutableListOf<String?>()
+        KMPAuth.setLogger { message -> received.add(message) }
+
+        currentLogger.log("hello")
+        currentLogger.log(null)
+
+        assertEquals(listOf("hello", null), received)
+    }
+
+    @Test
+    fun setLoggerReplacesPreviousLogger() {
+        val first = mutableListOf<String?>()
+        val second = mutableListOf<String?>()
+        KMPAuth.setLogger { first.add(it) }
+        KMPAuth.setLogger { second.add(it) }
+
+        currentLogger.log("only-second")
+
+        assertEquals(emptyList(), first)
+        assertEquals(listOf<String?>("only-second"), second)
+    }
+}

--- a/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/di/DiLifecycleTest.kt
+++ b/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/di/DiLifecycleTest.kt
@@ -1,0 +1,58 @@
+package com.mmk.kmpauth.core.di
+
+import com.mmk.kmpauth.core.KMPAuthInternalApi
+import io.ktor.client.HttpClient
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Characterization test locking the 2.x DI lifecycle contract of
+ * [LibDependencyInitializer] and [KMPKoinComponent].
+ *
+ * [LibDependencyInitializer] is a process-wide singleton with no reset hook,
+ * so the whole lifecycle is asserted in one ordered test method — individual
+ * test methods would depend on execution order.
+ *
+ * Contract locked here (the manual-DI replacement must preserve it):
+ * 1. Resolving anything before initialize() fails with
+ *    IllegalArgumentException("Make sure you invoked #initialize method").
+ * 2. initialize() creates the container and makes HttpClient resolvable.
+ * 3. initialize() is idempotent — subsequent calls are no-ops keeping the
+ *    same container instance.
+ */
+@OptIn(KMPAuthInternalApi::class)
+class DiLifecycleTest {
+
+    private class TestComponent : KMPKoinComponent()
+
+    @Test
+    fun lifecycle_uninitializedFails_initializeResolves_reinitializeIsNoOp() {
+        // 1. Before initialize(): resolution must fail with the exact message.
+        if (LibDependencyInitializer.koinApp == null) {
+            val failure = assertFailsWith<IllegalArgumentException> {
+                TestComponent().getKoin()
+            }
+            assertTrue(
+                failure.message.orEmpty().contains("Make sure you invoked #initialize method"),
+                "Unexpected error message: ${failure.message}"
+            )
+        }
+
+        // 2. initialize() creates the container; HttpClient is registered.
+        LibDependencyInitializer.initialize()
+        val koinApp = LibDependencyInitializer.koinApp
+        assertNotNull(koinApp, "koinApp must be set after initialize()")
+        val httpClient = koinApp.koin.get<HttpClient>()
+        assertNotNull(httpClient)
+
+        // 3. Re-initialize is a no-op: same container instance survives.
+        LibDependencyInitializer.initialize()
+        assertSame(koinApp, LibDependencyInitializer.koinApp)
+
+        // KMPKoinComponent now resolves through the initialized container.
+        assertSame(koinApp.koin, TestComponent().getKoin())
+    }
+}

--- a/kmpauth-google/build.gradle.kts
+++ b/kmpauth-google/build.gradle.kts
@@ -71,6 +71,10 @@ kotlin {
             implementation(libs.ktor.server.html.builder)
             implementation("com.auth0:java-jwt:4.4.0") // Check for the latest version
         }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
     }
 }
 

--- a/kmpauth-google/src/commonTest/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderDelegationTest.kt
+++ b/kmpauth-google/src/commonTest/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderDelegationTest.kt
@@ -1,0 +1,79 @@
+package com.mmk.kmpauth.google
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Characterization tests locking the overload-delegation contract of
+ * [GoogleAuthUiProvider]. The no-arg and two-arg [GoogleAuthUiProvider.signIn]
+ * overloads are default interface methods that must forward to the full
+ * overload with these exact defaults — user code and the Firebase containers
+ * rely on them.
+ */
+class GoogleAuthUiProviderDelegationTest {
+
+    private class RecordingProvider : GoogleAuthUiProvider {
+        var filterByAuthorizedAccounts: Boolean? = null
+        var isAutoSelectEnabled: Boolean? = null
+        var scopes: List<String>? = null
+
+        override suspend fun signIn(
+            filterByAuthorizedAccounts: Boolean,
+            isAutoSelectEnabled: Boolean,
+            scopes: List<String>,
+        ): GoogleUser? {
+            this.filterByAuthorizedAccounts = filterByAuthorizedAccounts
+            this.isAutoSelectEnabled = isAutoSelectEnabled
+            this.scopes = scopes
+            return null
+        }
+    }
+
+    @Test
+    fun noArgSignInUsesDocumentedDefaults() = runTest {
+        val provider = RecordingProvider()
+
+        provider.signIn()
+
+        assertEquals(false, provider.filterByAuthorizedAccounts)
+        assertEquals(true, provider.isAutoSelectEnabled)
+        assertEquals(listOf("email", "profile"), provider.scopes)
+    }
+
+    @Test
+    fun twoArgSignInForwardsArgsAndDefaultScopes() = runTest {
+        val provider = RecordingProvider()
+
+        provider.signIn(filterByAuthorizedAccounts = true, isAutoSelectEnabled = false)
+
+        assertEquals(true, provider.filterByAuthorizedAccounts)
+        assertEquals(false, provider.isAutoSelectEnabled)
+        assertEquals(listOf("email", "profile"), provider.scopes)
+    }
+
+    @Test
+    fun twoArgSignInDefaultsAutoSelectToTrue() = runTest {
+        val provider = RecordingProvider()
+
+        provider.signIn(filterByAuthorizedAccounts = true)
+
+        assertEquals(true, provider.filterByAuthorizedAccounts)
+        assertEquals(true, provider.isAutoSelectEnabled)
+        assertEquals(listOf("email", "profile"), provider.scopes)
+    }
+
+    @Test
+    fun fullOverloadPassesCustomScopesThrough() = runTest {
+        val provider = RecordingProvider()
+        val customScopes = listOf("email", "profile", "https://www.googleapis.com/auth/drive.readonly")
+
+        provider.signIn(
+            filterByAuthorizedAccounts = false,
+            isAutoSelectEnabled = true,
+            scopes = customScopes,
+        )
+
+        assertEquals(customScopes, provider.scopes)
+    }
+}

--- a/kmpauth-google/src/commonTest/kotlin/com/mmk/kmpauth/google/GoogleModelsTest.kt
+++ b/kmpauth-google/src/commonTest/kotlin/com/mmk/kmpauth/google/GoogleModelsTest.kt
@@ -1,0 +1,44 @@
+package com.mmk.kmpauth.google
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Characterization tests locking the public model shapes shipped in 2.x.
+ * These models cross the library boundary (returned to user code), so their
+ * defaults and value semantics are part of the public contract.
+ */
+class GoogleModelsTest {
+
+    @Test
+    fun googleUserDefaults() {
+        val user = GoogleUser(idToken = "token-123")
+
+        assertEquals("token-123", user.idToken)
+        assertNull(user.accessToken)
+        assertNull(user.email)
+        assertEquals("", user.displayName)
+        assertNull(user.profilePicUrl)
+        assertNull(user.serverAuthCode)
+    }
+
+    @Test
+    fun googleUserValueSemantics() {
+        val a = GoogleUser(idToken = "t", email = "a@b.c", displayName = "Name")
+        val b = GoogleUser(idToken = "t", email = "a@b.c", displayName = "Name")
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertEquals(a.copy(email = "x@y.z"), b.copy(email = "x@y.z"))
+    }
+
+    @Test
+    fun googleAuthCredentialsValueSemantics() {
+        val a = GoogleAuthCredentials(serverId = "web-client-id")
+        val b = GoogleAuthCredentials(serverId = "web-client-id")
+
+        assertEquals("web-client-id", a.serverId)
+        assertEquals(a, b)
+    }
+}

--- a/kmpauth-google/src/jvmTest/kotlin/com/mmk/kmpauth/google/GoogleAuthProviderLifecycleTest.kt
+++ b/kmpauth-google/src/jvmTest/kotlin/com/mmk/kmpauth/google/GoogleAuthProviderLifecycleTest.kt
@@ -1,0 +1,47 @@
+package com.mmk.kmpauth.google
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+/**
+ * Characterization test locking the [GoogleAuthProvider] entry-point contract
+ * on JVM (the JVM implementation has no platform prerequisites, so the full
+ * create/get round-trip is safe to exercise here).
+ *
+ * The provider registry is process-global with no reset hook, so the whole
+ * lifecycle is asserted in one ordered test method.
+ *
+ * Contract locked here (the manual-DI replacement must preserve it):
+ * 1. get() before create() throws IllegalArgumentException with the exact
+ *    documented message.
+ * 2. create(credentials) returns a working provider.
+ * 3. get() after create() succeeds; create() stays callable (idempotent
+ *    initialization) and signOut() does not throw.
+ */
+class GoogleAuthProviderLifecycleTest {
+
+    @Test
+    fun lifecycle_getBeforeCreateFails_createThenGetSucceeds() = runTest {
+        // 1. get() before create(): exact error message is public contract.
+        val failure = assertFailsWith<IllegalArgumentException> {
+            GoogleAuthProvider.get()
+        }
+        assertEquals(
+            "Make sure you invoked GoogleAuthProvider #create method with providing credentials",
+            failure.message,
+        )
+
+        // 2. create() returns a provider.
+        val created = GoogleAuthProvider.create(GoogleAuthCredentials(serverId = "test-server-id"))
+        assertNotNull(created)
+
+        // 3. get() now succeeds; repeated create() is still safe; signOut()
+        //    is a no-op on JVM and must not throw.
+        assertNotNull(GoogleAuthProvider.get())
+        assertNotNull(GoogleAuthProvider.create(GoogleAuthCredentials(serverId = "another-id")))
+        created.signOut()
+    }
+}


### PR DESCRIPTION
## Why

First step of the 3.0.0 effort: the library has zero tests, and the upcoming refactors (Koin removal, manual DI, AGP 9, CocoaPods→SPM) need a behavioral safety net. The binary-compatibility dumps lock signatures; these tests lock behavior.

## What

**No production code is touched.** Test-only additions plus CI wiring:

- `kmpauth-core` commonTest:
  - `DiLifecycleTest` — `LibDependencyInitializer` contract: exact fail-before-init message, HttpClient registration, idempotent re-init (single ordered method; the singleton has no reset hook)
  - `LoggerContractTest` — `KMPAuth.setLogger` routing/replacement
  - `HttpClientFactoryTest` — factory semantics
- `kmpauth-google` commonTest:
  - `GoogleAuthUiProviderDelegationTest` — overload delegation + documented defaults (`filterByAuthorizedAccounts=false`, `isAutoSelectEnabled=true`, `scopes=[email, profile]`)
  - `GoogleModelsTest` — `GoogleUser` defaults/value semantics, `GoogleAuthCredentials`
- `kmpauth-google` jvmTest:
  - `GoogleAuthProviderLifecycleTest` — exact `get()`-before-`create()` error message, create/get round trip (JVM impl has no platform prerequisites)
- CI: `jvmTest` added to the android matrix leg; PR builds now also trigger for PRs targeting `rel_3.0.0`
- Catalog: `kotlinx-coroutines-test` added

## Verification

Locally green: `jvmTest`, `testDebugUnitTest`, `iosSimulatorArm64Test`, `apiCheck` (zero dump changes — proof no public API moved).

Part of the 3.0.0 release plan (Phase 2 — safety net). Targets `rel_3.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)