### PR TITLE
test: Facebook/Apple model contracts + CHANGELOG/MIGRATION scaffolds (PR-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to KMPAuth are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] — 3.0.0
+
+See [MIGRATION.md](MIGRATION.md) for the step-by-step 2.x → 3.0 upgrade guide.
+
+### Added
+- Characterization test suite locking the public 2.x behavior (DI lifecycle,
+  `GoogleAuthProvider` entry points, sign-in overload defaults, public model shapes).
+
+### Changed
+- _(pending)_ Build toolchain: AGP 9, Gradle 9.4, Kotlin 2.4, JVM target 17.
+- _(pending)_ iOS dependencies distributed via Swift Package Manager instead of
+  CocoaPods; iOS minimum deployment target raised to 16.0.
+
+### Deprecated
+- _(pending)_ Legacy overloads slated for removal in 4.0 carry
+  `@Deprecated(ReplaceWith(...))` with migration hints.
+
+### Removed
+- _(pending)_ Koin-based internal DI (`KMPKoinComponent`, `LibDependencyInitializer`,
+  `org.koin` dependency). These were `@KMPAuthInternalApi`-annotated internals.
+
+## [2.5.0-alpha01] — 2026-06
+
+### Added
+- Dedicated Facebook auth modules: `kmpauth-facebook` (SDK-only) and
+  `kmpauth-firebase-facebook` (Facebook + Firebase) (#163).
+- `iosX64` target restored (#164).
+
+### Fixed
+- Google JVM sign-in uses a dynamically found port for the OAuth redirect URI (#165).
+
+## [2.4.0] — 2025
+
+### Added
+- `setAutoSelectEnabled(isAutoSelectEnabled)` on Google sign-in (#126).
+- Non-legacy Google sign-in with custom scopes on Android (#132).
+
+### Fixed
+- Icon and text alignment in `FacebookSignInButton` (#142).
+- Compatibility with Firebase Android BoM 34.0.0 (#141).
+
+_Older releases: see [GitHub releases](https://github.com/mirzemehdi/KMPAuth/releases)._

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,51 @@
+# Migrating KMPAuth 2.x → 3.0
+
+Step-by-step guide for upgrading. Sections marked _(pending)_ are filled in as
+the corresponding 3.0 changes land on the `rel_3.0.0` integration branch.
+
+## TL;DR checklist
+
+- [ ] Bump `io.github.mirzemehdi:kmpauth-*` to `3.0.0`.
+- [ ] _(pending)_ iOS: replace CocoaPods pods with Swift Package Manager packages;
+      raise your app's iOS deployment target to 16.0 and use Xcode 16.4+.
+- [ ] _(pending)_ Desktop/JVM: run on Java 17+ (artifacts now target JVM 17 bytecode).
+- [ ] If you referenced the `@KMPAuthInternalApi` DI types directly
+      (`KMPKoinComponent`, `LibDependencyInitializer`): remove those usages —
+      they are deleted in 3.0. Public entry points (`GoogleAuthProvider.create`,
+      the `*UiContainer` composables) are unchanged and need no code changes.
+- [ ] Address `@Deprecated` warnings — each carries a `ReplaceWith` migration hint.
+
+## What did NOT change
+
+- All public composable containers keep their 2.x signatures:
+  `GoogleButtonUiContainer`, `GoogleButtonUiContainerFirebase`,
+  `AppleButtonUiContainer`, `GithubButtonUiContainer`, `OAuthContainer`,
+  `FacebookButtonUiContainer`, `FacebookButtonUiContainerFirebase`, and the
+  `kmpauth-uihelper` buttons.
+- `GoogleAuthProvider.create(credentials)` initialization flow.
+- Public models: `GoogleUser`, `GoogleAuthCredentials`, `FacebookUser`,
+  request-scope types.
+- Maven coordinates (`io.github.mirzemehdi:kmpauth-*`).
+
+## 1. iOS: CocoaPods → Swift Package Manager _(pending)_
+
+_Instructions land with the SPM migration PR._
+
+## 2. Koin removal _(pending)_
+
+KMPAuth no longer uses (or ships) Koin. Details land with the DI PRs.
+
+## 3. Toolchain requirements _(pending)_
+
+| Requirement | 2.x | 3.0 |
+|---|---|---|
+| iOS deployment target | 11.0–12.0 | 16.0 _(pending)_ |
+| Xcode | 15+ | 16.4+ _(pending)_ |
+| JVM bytecode | 1.8 | 17 _(pending)_ |
+| Android debug variant artifact | published | no longer published (single-variant; debug builds resolve the release variant automatically) _(pending)_ |
+
+## 4. Pluggable auth backends _(pending)_
+
+3.0 introduces an `AuthProviderBackend` abstraction (Firebase remains the
+default implementation; a Supabase implementation is planned). Existing
+Firebase-based code keeps working unchanged.

--- a/kmpauth-facebook/build.gradle.kts
+++ b/kmpauth-facebook/build.gradle.kts
@@ -65,6 +65,10 @@ kotlin {
             implementation(libs.koin.compose)
             api(project(":kmpauth-core"))
         }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
     }
 }
 

--- a/kmpauth-facebook/src/commonTest/kotlin/com/mmk/kmpauth/facebook/FacebookModelsTest.kt
+++ b/kmpauth-facebook/src/commonTest/kotlin/com/mmk/kmpauth/facebook/FacebookModelsTest.kt
@@ -1,0 +1,44 @@
+package com.mmk.kmpauth.facebook
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Characterization tests locking the public Facebook model shapes shipped
+ * in 2.x. These cross the library boundary, so defaults and value semantics
+ * are part of the public contract.
+ */
+class FacebookModelsTest {
+
+    @Test
+    fun facebookUserDefaults() {
+        val user = FacebookUser()
+
+        assertNull(user.accessToken)
+        assertNull(user.nonce)
+    }
+
+    @Test
+    fun facebookUserValueSemantics() {
+        val a = FacebookUser(accessToken = "token", nonce = "nonce")
+        val b = FacebookUser(accessToken = "token", nonce = "nonce")
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertEquals(a.copy(nonce = "other"), b.copy(nonce = "other"))
+    }
+
+    @Test
+    fun requestScopeObjectsAreSingletonsAndDistinct() {
+        val scopes: List<FacebookSignInRequestScope> = listOf(
+            FacebookSignInRequestScope.PublicProfile,
+            FacebookSignInRequestScope.Email,
+        )
+
+        assertEquals(2, scopes.distinct().size)
+        assertTrue(FacebookSignInRequestScope.PublicProfile is FacebookSignInRequestScope)
+        assertTrue(FacebookSignInRequestScope.Email is FacebookSignInRequestScope)
+    }
+}

--- a/kmpauth-firebase/build.gradle.kts
+++ b/kmpauth-firebase/build.gradle.kts
@@ -63,6 +63,10 @@ kotlin {
             api(project(":kmpauth-core"))
             implementation(project(":kmpauth-google"))
         }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
     }
 }
 

--- a/kmpauth-firebase/src/commonTest/kotlin/com/mmk/kmpauth/firebase/apple/AppleSignInRequestScopeTest.kt
+++ b/kmpauth-firebase/src/commonTest/kotlin/com/mmk/kmpauth/firebase/apple/AppleSignInRequestScopeTest.kt
@@ -1,0 +1,26 @@
+package com.mmk.kmpauth.firebase.apple
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Characterization test locking the public [AppleSignInRequestScope] shape
+ * shipped in 2.x: exactly two scope objects, both usable as list elements
+ * (the default request-scope list of AppleButtonUiContainer is
+ * [FullName, Email]).
+ */
+class AppleSignInRequestScopeTest {
+
+    @Test
+    fun requestScopeObjectsAreSingletonsAndDistinct() {
+        val scopes: List<AppleSignInRequestScope> = listOf(
+            AppleSignInRequestScope.FullName,
+            AppleSignInRequestScope.Email,
+        )
+
+        assertEquals(2, scopes.distinct().size)
+        assertTrue(AppleSignInRequestScope.FullName is AppleSignInRequestScope)
+        assertTrue(AppleSignInRequestScope.Email is AppleSignInRequestScope)
+    }
+}


### PR DESCRIPTION
## Why

Completes the Phase 2 safety net: remaining public model shapes pinned before refactoring starts, and documentation scaffolds created so every subsequent 3.0 PR appends its user-facing changes as it lands.

## What

**No production code is touched.**

- `kmpauth-facebook` commonTest: `FacebookUser` defaults/value semantics, `FacebookSignInRequestScope` sealed hierarchy
- `kmpauth-firebase` commonTest: `AppleSignInRequestScope` sealed hierarchy
- `CHANGELOG.md` — Keep a Changelog format, retroactive 2.5.0-alpha01/2.4.0 entries, Unreleased 3.0.0 section with pending items
- `MIGRATION.md` — 2.x→3.0 skeleton: TL;DR checklist, "what did NOT change" section, pending sections for SPM/Koin/toolchain

Firebase composable flows intentionally not unit-tested (need live FirebaseApp); ABI locked via api dumps, orchestration seam comes with the backend-abstraction PR.

## Verification

`testDebugUnitTest` + `jvmTest` green for both modules.

Part of the 3.0.0 release plan (Phase 2). Targets `rel_3.0.0`. Independent of #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)