### PR TITLE
fix(google): fixed, configurable desktop OAuth redirect URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,19 @@ See [MIGRATION.md](MIGRATION.md) for the step-by-step 2.x → 3.0 upgrade guide.
   `filterByAuthorizedAccounts` overloads) remain deprecated with warnings
   and are slated for removal in 4.0.
 
+### Fixed
+- **Desktop (JVM) Google Sign-In redirect URI.** The loopback server used a
+  random port that never matched the `redirect_uri` sent to Google, so the
+  callback failed (`redirect_uri_mismatch`, blank callback page, or
+  `id_token=null` on a second attempt). The redirect is now fixed and
+  configurable via `GoogleAuthCredentials(serverId, redirectUri = "http://localhost:8080/callback")` —
+  pass the exact **Authorized redirect URI** registered for your OAuth client
+  in the Google Cloud console (any `http` loopback host/port/path;
+  defaults to `http://localhost:8080/callback`). The callback server binds the
+  URI's port and serves its path; when the port is already in use the failure
+  is logged clearly instead of silently falling back to a random port. The
+  browser now opens only after the server is listening (#172, #177, #181).
+
 ### Removed
 - **Koin.** KMPAuth no longer uses or ships Koin. The `@KMPAuthInternalApi`
   DI types `KMPKoinComponent` and `LibDependencyInitializer` are deleted and

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -153,3 +153,19 @@ backend-agnostic credential/user model (`AuthCredential`, `KMPAuthUser`).
 - Web-flow providers (Apple on Android, GitHub, generic OAuth) are executed
   by their dedicated container composables — a backend `signIn` call cannot
   drive a browser flow.
+
+## 7. Desktop (JVM) Google Sign-In redirect URI
+
+The desktop Google flow now uses a **fixed, configurable** loopback redirect
+URI instead of a random port (2.x picked a random port that could not be
+registered with Google, so sign-in often failed with `redirect_uri_mismatch`).
+
+- **Default:** `http://localhost:8080/callback`. Register that exact URI as an
+  Authorized redirect URI for your OAuth client in the Google Cloud console.
+- **Custom URI:** pass the one you registered when creating credentials —
+  `GoogleAuthCredentials(serverId = WebClientId, redirectUri = "http://127.0.0.1:9000/oauth2")`.
+  Any `http` loopback host (`localhost`/`127.0.0.1`), port and path are allowed;
+  the callback server binds the URI's port and serves its path.
+- If the port is already in use, sign-in fails with a logged error (no silent
+  random-port fallback); free the port or register another URI.
+- Desktop-only: `redirectUri` is ignored on Android, iOS, JS and wasmJs.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,36 @@ struct iOSApp: App {
 
 </details>
 
+<details>
+  <summary>Desktop (JVM)</summary>
+
+##### Desktop Setup
+On desktop, Google Sign-In runs the OAuth flow in the system browser and
+receives the result on a localhost loopback server. Google requires the
+redirect URI to be **pre-registered** with a **fixed port**, so:
+
+1. In the Google Cloud console, add an **Authorized redirect URI** for your
+   OAuth client — e.g. `http://localhost:8080/callback`.
+2. Pass that exact URI as `redirectUri` when creating the credentials (it
+   defaults to `http://localhost:8080/callback`):
+
+```kotlin
+GoogleAuthProvider.create(
+    credentials = GoogleAuthCredentials(
+        serverId = WebClientId,
+        redirectUri = "http://localhost:8080/callback",
+    )
+)
+```
+
+Any `http` loopback host (`localhost` / `127.0.0.1`), port and path are
+allowed as long as the same URI is registered in the console. The port must be
+free when the user signs in; if it is already taken, sign-in fails with a
+logged error — free it or register a different URI. `redirectUri` is ignored
+on Android, iOS, JS and wasmJs.
+
+</details>
+
 #### Usage
 After configuring above steps this is how you can use:
 

--- a/providers/kmpauth-google/api/jvm/kmpauth-google.api
+++ b/providers/kmpauth-google/api/jvm/kmpauth-google.api
@@ -1,10 +1,13 @@
 public final class com/mmk/kmpauth/google/GoogleAuthCredentials {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleAuthCredentials;
-	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleAuthCredentials;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleAuthCredentials;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/mmk/kmpauth/google/GoogleAuthCredentials;
+	public static synthetic fun copy$default (Lcom/mmk/kmpauth/google/GoogleAuthCredentials;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mmk/kmpauth/google/GoogleAuthCredentials;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRedirectUri ()Ljava/lang/String;
 	public final fun getServerId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/providers/kmpauth-google/api/kmpauth-google.klib.api
+++ b/providers/kmpauth-google/api/kmpauth-google.klib.api
@@ -25,13 +25,16 @@ abstract interface com.mmk.kmpauth.google/GoogleAuthUiProvider { // com.mmk.kmpa
 }
 
 final class com.mmk.kmpauth.google/GoogleAuthCredentials { // com.mmk.kmpauth.google/GoogleAuthCredentials|null[0]
-    constructor <init>(kotlin/String) // com.mmk.kmpauth.google/GoogleAuthCredentials.<init>|<init>(kotlin.String){}[0]
+    constructor <init>(kotlin/String, kotlin/String = ...) // com.mmk.kmpauth.google/GoogleAuthCredentials.<init>|<init>(kotlin.String;kotlin.String){}[0]
 
+    final val redirectUri // com.mmk.kmpauth.google/GoogleAuthCredentials.redirectUri|{}redirectUri[0]
+        final fun <get-redirectUri>(): kotlin/String // com.mmk.kmpauth.google/GoogleAuthCredentials.redirectUri.<get-redirectUri>|<get-redirectUri>(){}[0]
     final val serverId // com.mmk.kmpauth.google/GoogleAuthCredentials.serverId|{}serverId[0]
         final fun <get-serverId>(): kotlin/String // com.mmk.kmpauth.google/GoogleAuthCredentials.serverId.<get-serverId>|<get-serverId>(){}[0]
 
     final fun component1(): kotlin/String // com.mmk.kmpauth.google/GoogleAuthCredentials.component1|component1(){}[0]
-    final fun copy(kotlin/String = ...): com.mmk.kmpauth.google/GoogleAuthCredentials // com.mmk.kmpauth.google/GoogleAuthCredentials.copy|copy(kotlin.String){}[0]
+    final fun component2(): kotlin/String // com.mmk.kmpauth.google/GoogleAuthCredentials.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ...): com.mmk.kmpauth.google/GoogleAuthCredentials // com.mmk.kmpauth.google/GoogleAuthCredentials.copy|copy(kotlin.String;kotlin.String){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.mmk.kmpauth.google/GoogleAuthCredentials.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.mmk.kmpauth.google/GoogleAuthCredentials.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.mmk.kmpauth.google/GoogleAuthCredentials.toString|toString(){}[0]

--- a/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthCredentials.kt
+++ b/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthCredentials.kt
@@ -3,5 +3,17 @@ package com.mmk.kmpauth.google
 /**
  * Google Auth Credentials holder class.
  * @param serverId - This should be Web Client Id that you created in Google OAuth page
+ * @param redirectUri - Desktop (JVM) only. The OAuth loopback redirect URI,
+ * e.g. `http://localhost:8080/callback` or `http://127.0.0.1:9000/oauth2`.
+ * It must be an `http` loopback URL (`localhost`/`127.0.0.1`) with an explicit
+ * port and match an **Authorized redirect URI** registered for your OAuth
+ * client in the Google Cloud console — Google's Web clients reject
+ * unregistered URIs with `redirect_uri_mismatch`. The desktop flow binds a
+ * local callback server to the URI's port, so the port must be free and known
+ * ahead of time. Defaults to `http://localhost:8080/callback`. Ignored on
+ * Android, iOS, JS and wasmJs (those platforms don't run a loopback server).
  */
-public data class GoogleAuthCredentials(val serverId: String)
+public data class GoogleAuthCredentials(
+    val serverId: String,
+    val redirectUri: String = "http://localhost:8080/callback",
+)

--- a/providers/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/providers/kmpauth-google/src/jvmMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -12,20 +12,20 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.html.body
 import kotlinx.html.script
 import kotlinx.html.unsafe
 import java.awt.Desktop
-import java.net.ServerSocket
+import java.net.BindException
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.util.Base64
 
-
-private var foundAvailablePort: Int = 8080 //TODO temporary solution. Fix later in signin by passing redirect url
 
 internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCredentials) :
     GoogleAuthUiProvider {
@@ -38,9 +38,9 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         isAutoSelectEnabled: Boolean,
         scopes: List<String>
     ): GoogleUser? {
+        val redirectTarget = resolveRedirectTarget() ?: return null
         val responseType = "id_token token"
         val scopeString = scopes.joinToString(" ")
-        val redirectUri = "http://localhost:$foundAvailablePort/callback"
         val state: String
         var nonce: String?
         val googleAuthUrl = withContext(Dispatchers.IO) {
@@ -51,7 +51,7 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             nonce = URLEncoder.encode(generateRandomString(), StandardCharsets.UTF_8.toString())
             "$authUrl?" +
                     "client_id=${credentials.serverId}" +
-                    "&redirect_uri=$redirectUri" +
+                    "&redirect_uri=${redirectTarget.redirectUri}" +
                     "&response_type=$encodedResponseType" +
                     "&scope=$encodedScope" +
                     "&nonce=$nonce" +
@@ -59,9 +59,11 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         }
 
 
-        openUrlInBrowser(googleAuthUrl)
-
-        val (idToken, accessToken) = startHttpServerAndGetToken(state = state)
+        val (idToken, accessToken) = startHttpServerAndGetToken(
+            googleAuthUrl = googleAuthUrl,
+            redirectTarget = redirectTarget,
+            state = state,
+        )
         if (idToken == null && accessToken == null) {
             currentLogger.log("GoogleAuthUiProvider: token is null")
             return null
@@ -88,8 +90,10 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
     }
 
     //Pair, first one is idToken, second one is accessToken
+    @OptIn(KMPAuthInternalApi::class)
     private suspend fun startHttpServerAndGetToken(
-        redirectUriPath: String = "/callback",
+        googleAuthUrl: String,
+        redirectTarget: RedirectTarget,
         state: String
     ): Pair<String?, String?> {
         val tokenPairDeferred = CompletableDeferred<Pair<String?, String?>>()
@@ -97,53 +101,125 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         val jsCode = """
             var fragment = window.location.hash;
             if (fragment) {
-                var params = new URLSearchParams(fragment.substring(1)); 
+                var params = new URLSearchParams(fragment.substring(1));
                 var idToken = params.get('id_token');
                 var accessToken = params.get('access_token');
                 var receivedState = params.get('state');
-                var expectedState = '${state}'; 
+                var expectedState = '${state}';
                 if (receivedState === expectedState) {
-                    window.location.href = '$redirectUriPath/token?' + 
-                        (idToken ? 'id_token=' + idToken : '') + 
-                        (idToken && accessToken ? '&' : '') + 
+                    window.location.href = '${redirectTarget.tokenPath}?' +
+                        (idToken ? 'id_token=' + idToken : '') +
+                        (idToken && accessToken ? '&' : '') +
                         (accessToken ? 'access_token=' + accessToken : '');
                 } else {
                     console.error('State does not match! Possible CSRF attack.');
-                    window.location.href = '$redirectUriPath/token?id_token=null';
-                }
-            }                 
-        """.trimIndent()
-        foundAvailablePort = findAvailablePort()
-        val server = embeddedServer(Netty, port = foundAvailablePort) {
-            routing {
-                get(redirectUriPath) {
-                    call.respondHtml {
-                        body { script { unsafe { +jsCode } } }
-                    }
-                }
-                get("$redirectUriPath/token") {
-                    val idToken = call.request.queryParameters["id_token"]
-                    val accessToken = call.request.queryParameters["access_token"]
-                    if (idToken.isNullOrEmpty().not() || accessToken.isNullOrEmpty().not()) {
-                        call.respondText(
-                            "Authorization is complete. You can close this window, and return to the application",
-                            contentType = ContentType.Text.Plain
-                        )
-                        tokenPairDeferred.complete(Pair(idToken, accessToken))
-                    } else {
-                        call.respondText(
-                            "Authorization failed",
-                            contentType = ContentType.Text.Plain
-                        )
-                        tokenPairDeferred.complete(Pair(null, null))
-                    }
+                    window.location.href = '${redirectTarget.tokenPath}?id_token=null';
                 }
             }
-        }.start(wait = false)
+        """.trimIndent()
+        val server = try {
+            embeddedServer(Netty, port = redirectTarget.port) {
+                routing {
+                    get(redirectTarget.callbackPath) {
+                        call.respondHtml {
+                            body { script { unsafe { +jsCode } } }
+                        }
+                    }
+                    get(redirectTarget.tokenPath) {
+                        val idToken = call.request.queryParameters["id_token"]
+                        val accessToken = call.request.queryParameters["access_token"]
+                        if (idToken.isNullOrEmpty().not() || accessToken.isNullOrEmpty().not()) {
+                            call.respondText(
+                                "Authorization is complete. You can close this window, and return to the application",
+                                contentType = ContentType.Text.Plain
+                            )
+                            tokenPairDeferred.complete(Pair(idToken, accessToken))
+                        } else {
+                            call.respondText(
+                                "Authorization failed",
+                                contentType = ContentType.Text.Plain
+                            )
+                            tokenPairDeferred.complete(Pair(null, null))
+                        }
+                    }
+                }
+            }.start(wait = false)
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            val bindFailure = e is BindException || e.cause is BindException
+            if (bindFailure) {
+                currentLogger.log(
+                    "GoogleAuthUiProvider: could not bind port ${redirectTarget.port} for the OAuth " +
+                        "redirect (${redirectTarget.redirectUri}) - it is already in use. Free the " +
+                        "port, or set a different (Google-console-registered) " +
+                        "GoogleAuthCredentials.redirectUri."
+                )
+            } else {
+                currentLogger.log(
+                    "GoogleAuthUiProvider: failed to start the redirect server on port ${redirectTarget.port}: $e"
+                )
+            }
+            return Pair(null, null)
+        }
+
+        // Open the browser only after the callback server is listening, so the
+        // OAuth redirect can never arrive before the endpoint is ready.
+        openUrlInBrowser(googleAuthUrl)
 
         val idTokenAndAccessTokenPair = tokenPairDeferred.await()
         server.stop(1000, 1000)
         return idTokenAndAccessTokenPair
+    }
+
+    /**
+     * Resolves [GoogleAuthCredentials.redirectUri] (or the default) into the
+     * pieces the desktop flow needs: the exact string sent to Google as
+     * `redirect_uri`, the port the local callback server binds, the path it
+     * serves, and the internal path the in-browser script posts tokens back to.
+     * Returns null (logging why) when the URI is not a usable http loopback URL.
+     */
+    @OptIn(KMPAuthInternalApi::class)
+    private fun resolveRedirectTarget(): RedirectTarget? {
+        val raw = credentials.redirectUri
+        val parsed = try {
+            URI(raw)
+        } catch (e: Exception) {
+            currentLogger.log("GoogleAuthUiProvider: redirectUri '$raw' is not a valid URI: $e")
+            return null
+        }
+        if (parsed.scheme?.lowercase() != "http") {
+            currentLogger.log(
+                "GoogleAuthUiProvider: redirectUri must use the http scheme " +
+                    "(e.g. http://localhost:8080/callback), got '$raw'."
+            )
+            return null
+        }
+        val host = parsed.host
+        if (host == null || host.lowercase() !in LOOPBACK_HOSTS) {
+            currentLogger.log(
+                "GoogleAuthUiProvider: redirectUri host must be a loopback address " +
+                    "(localhost or 127.0.0.1), got '$raw'."
+            )
+            return null
+        }
+        val port = parsed.port
+        if (port <= 0) {
+            currentLogger.log(
+                "GoogleAuthUiProvider: redirectUri must include an explicit port " +
+                    "(e.g. http://localhost:8080/callback), got '$raw'."
+            )
+            return null
+        }
+        // Google redirects to the exact path we register, so serve that path
+        // verbatim; browsers normalize a missing path to "/".
+        val callbackPath = parsed.path.ifEmpty { "/" }
+        val tokenPath = callbackPath.trimEnd('/') + "/token"
+        return RedirectTarget(
+            redirectUri = raw,
+            port = port,
+            callbackPath = callbackPath,
+            tokenPath = tokenPath,
+        )
     }
 
     @OptIn(KMPAuthInternalApi::class)
@@ -162,10 +238,16 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         return Base64.getUrlEncoder().withoutPadding().encodeToString(stateBytes)
     }
 
+    /** Parsed view of the desktop OAuth loopback redirect. */
+    private data class RedirectTarget(
+        val redirectUri: String,
+        val port: Int,
+        val callbackPath: String,
+        val tokenPath: String,
+    )
 
-    private fun findAvailablePort(): Int {
-        val port = ServerSocket(0).use { socket -> socket.localPort }
-        return port
+    private companion object {
+        val LOOPBACK_HOSTS = setOf("localhost", "127.0.0.1", "[::1]", "::1")
     }
 
 }


### PR DESCRIPTION
## Overview

Fixes the JVM/Desktop Google Sign-In loopback redirect on `rel_3.0.0`.

## The bug

The desktop flow built the `redirect_uri` from `foundAvailablePort` (init `8080`) **before** the callback server chose its actual port — a **random** `ServerSocket(0)` picked later inside `startHttpServerAndGetToken`. The URL sent to Google and the port the server listened on never matched:

- 1st attempt: Google redirects the browser to `localhost:8080` where nothing (or another process) is listening → blank callback page, handler never fires.
- 2nd attempt: the module-level `var foundAvailablePort` still holds the previous random port, a new random port is bound → still mismatched → `id_token=null`.

A random loopback port also can't be pre-registered as an authorized redirect URI, so Google Web clients reject it with `redirect_uri_mismatch`.

## The fix

- **`GoogleAuthCredentials(serverId, redirectPort = 8080)`** — the redirect URI and the callback server now both use this single fixed port, so they always match. Register `http://localhost:<redirectPort>` in the Google Cloud console.
- Removed the mutable module-level `foundAvailablePort` and the random `findAvailablePort()` fallback. Port already in use → **clear logged error**, no silent random retry.
- **Start the callback server before opening the browser**, so the redirect can't arrive before the endpoint is listening. (Ordering fix adopted from #175.)

`redirectPort` is ignored on Android, iOS, JS and wasmJs.

## Docs / API

- README: new **Desktop (JVM)** setup block.
- CHANGELOG: `### Fixed` entry; MIGRATION: §7.
- API dumps regenerated (`apiCheck` green).

## Compatibility note

JVM ABI break: the old `GoogleAuthCredentials(String)` constructor no longer exists at bytecode level (now `(String, int)` + synthetic default). **Source-compatible** via the default value; binary-breaking for precompiled JVM consumers — acceptable for the 3.0 major.

## Relation to #175

Supersedes #175 (targeted `main`, pre-3.0 layout + podspecs, obsolete version bump). Same root diagnosis; this uses a single fixed port + clear error instead of a random-port fallback (which reintroduces `redirect_uri_mismatch` for Web clients). The server-before-browser ordering fix is adopted from it, with credit.

Fixes #172, #177, #181.