### PR TITLE
fix(facebook): use AndroidX Activity Result for classic login on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to KMPAuth are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Facebook on Android: classic login no longer requires `onActivityResult`.**
+  With `FacebookLoginTracking.Enabled`, KMPAuth now launches Facebook Login
+  through the SDK's `logInWithReadPermissions(ActivityResultRegistryOwner,
+  CallbackManager, permissions)` overload (the pattern used by Facebook's own
+  Compose sample), so apps no longer need to override `onActivityResult` or
+  call `KMPAuth.handleFacebookActivityResult` for that mode.
+  `FacebookLoginTracking.Limited` (the default) still needs it: Limited Login
+  requires a nonce, which the Facebook SDK only accepts via
+  `LoginConfiguration`, and that API has no `ActivityResultRegistryOwner`
+  overload — the SDK exposes one only as a `private` function. Calling
+  `handleFacebookActivityResult` when it is not needed remains harmless (#199).
+
 ## [3.0.0-alpha01] — 2026-07-08
 
 See [MIGRATION.md](MIGRATION.md) for the step-by-step 2.x → 3.0 upgrade guide.

--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ Add these metadata tags and Facebook Activity to your `AndroidManifest.xml` insi
     android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
     android:label="@string/app_name" />
 ```
-For Facebook Login, on Your Main Activity's activity result call `KMPAuth.handleFacebookActivityResult` function:
+When using `FacebookLoginTracking.Limited` (the **default**), forward your Main Activity's
+activity result to `KMPAuth.handleFacebookActivityResult`:
 
 ```kotlin
 override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -358,6 +359,13 @@ override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) 
     super.onActivityResult(requestCode, resultCode, data)
 }
 ```
+
+> **Why only for `Limited`?** Limited Login requires a nonce, which the Facebook SDK
+> accepts only through `LoginConfiguration` — an API that has no
+> `ActivityResultRegistryOwner` overload, so its result still arrives via
+> `onActivityResult`. With `FacebookLoginTracking.Enabled`, KMPAuth uses the SDK's
+> AndroidX Activity Result API and **no override is needed**. Calling
+> `handleFacebookActivityResult` when it isn't needed is harmless.
 
 #### IOS Setup
 Add Facebook Login SDK Swift Package, and add below to your Info.plist:

--- a/providers/kmpauth-facebook/src/androidMain/kotlin/com/mmk/kmpauth/facebook/FacebookSignInState.android.kt
+++ b/providers/kmpauth-facebook/src/androidMain/kotlin/com/mmk/kmpauth/facebook/FacebookSignInState.android.kt
@@ -29,7 +29,16 @@ import kotlin.coroutines.resume
 
 
 /**
- * You mush call `KMPAuth.handleFacebookActivityResult` from your Activity's onActivityResult to handle Facebook login.
+ * Forwards an `Activity#onActivityResult` callback to the Facebook SDK.
+ *
+ * **Only required for [FacebookLoginTracking.Limited]** (the default). Limited
+ * Login needs a nonce, which the Facebook SDK only accepts through
+ * `LoginConfiguration`, and that API has no AndroidX Activity Result variant —
+ * its results still arrive via `onActivityResult`. With
+ * [FacebookLoginTracking.Enabled] KMPAuth uses the SDK's
+ * `ActivityResultRegistryOwner` overload, so no override is needed.
+ *
+ * Calling this when it is not needed is harmless.
  *
  * Example:
  * ```
@@ -97,13 +106,23 @@ private suspend fun signIn(
                 }
             )
             when (loginTracking) {
+                // Limited Login needs a nonce, which the SDK only accepts via
+                // LoginConfiguration - an API with no ActivityResultRegistryOwner
+                // overload, so its result still arrives through onActivityResult
+                // (see KMPAuth.handleFacebookActivityResult).
                 FacebookLoginTracking.Limited -> {
                     val config = LoginConfiguration(permissions, sha256(rawNonce!!))
                     loginManager.logIn(activity as Activity, config)
                 }
 
+                // Classic login goes through the AndroidX Activity Result APIs,
+                // so callers do not need to override onActivityResult.
                 FacebookLoginTracking.Enabled ->
-                    loginManager.logInWithReadPermissions(activity as Activity, permissions)
+                    loginManager.logInWithReadPermissions(
+                        activity,
+                        facebookLoginCallbackManager,
+                        permissions,
+                    )
             }
         }
     } finally {


### PR DESCRIPTION
## Overview

Addresses #199 — Facebook Login on Android forced every consumer to override `onActivityResult` and forward it via `KMPAuth.handleFacebookActivityResult`, even though the Facebook SDK has supported the AndroidX Activity Result APIs since v12.0.0.

## The change

For **`FacebookLoginTracking.Enabled`** (classic login), launch via:

```kotlin
loginManager.logInWithReadPermissions(activity, facebookLoginCallbackManager, permissions)
```

`ComponentActivity` already implements `ActivityResultRegistryOwner`, so results are delivered through the activity result registry — **no `onActivityResult` override needed**. This is the same pattern Facebook's own Compose sample (`KotlinSampleApp/LoginMenuScreen.kt`) uses.

## Why `Limited` (the default) still needs it

Investigated the SDK thoroughly (javap on the pinned `facebook-common`/`facebook-login` 18.3.0 + the SDK source on `main`):

- Limited Login requires a caller-supplied **nonce**, which the SDK accepts only through `LoginConfiguration`.
- **No `ActivityResultRegistryOwner` overload accepts a `LoginConfiguration`.** `FacebookLoginActivityResultContract` is `ActivityResultContract<Collection<String>, …>` — permissions only. `LoginButton` has no nonce API either.
- The SDK *does* have exactly the overload we'd want — declared **`private`**:
  ```kotlin
  private fun logIn(activityResultRegistryOwner, callbackManager, loginConfig: LoginConfiguration)
  ```
- And the public `logIn(Activity, LoginConfiguration)` even logs a warning telling you to upgrade to the AndroidX APIs — while giving no public way to do so. That warning is very likely what prompted #199.
- 18.3.0 is the latest release; no upstream fix available. Meta documents Limited Login for **iOS and Unity only** — there is no Android Limited Login guide.

Reaching the private path would mean subclassing `LoginManager` for its `protected createLoginRequestWithConfig`/`getFacebookActivityIntent` and hand-rolling the launch + `CallbackManagerImpl.RequestCodeOffset` result routing — undocumented internals, on the **default** sign-in path, untestable in CI. Not a trade-off worth making for an auth library.

## Docs

`handleFacebookActivityResult` KDoc + README now state it is required **only** for `Limited`, and that calling it otherwise is harmless. CHANGELOG entry under Unreleased.

## Verification

`compileAndroidMain` + `apiCheck` green. No public API change (implementation + docs only).

⚠️ Runtime not device-tested (no Facebook app credentials in CI) — worth a real-device check of classic login before release.

Refs #199.
