### PR TITLE
fix(google): don't resolve the auth provider in IDE previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to KMPAuth are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Google sign-in composables no longer crash IDE previews** (#162).
+  `rememberGoogleSignInState` and `rememberFirebaseGoogleSignInState` resolved
+  the provider during composition via `GoogleAuthProvider.get()`, which throws
+  `IllegalArgumentException` when `create()` has not been called — and a
+  `@Preview` never runs application startup. Both now return an inert
+  `SignInState` when `LocalInspectionMode` is true, so previews render and
+  `launch()` is a no-op. The deprecated `GoogleButtonUiContainer` /
+  `GoogleButtonUiContainerFirebase` are thin wrappers over these states, so
+  they are fixed too.
+
 ## [3.0.0-alpha02] — 2026-07-19
 
 ### Fixed

--- a/backends/firebase/kmpauth-firebase-google/src/nonWasmMain/kotlin/com/mmk/kmpauth/firebase/google/FirebaseGoogleSignInState.kt
+++ b/backends/firebase/kmpauth-firebase-google/src/nonWasmMain/kotlin/com/mmk/kmpauth/firebase/google/FirebaseGoogleSignInState.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalInspectionMode
 import com.mmk.kmpauth.core.KMPAuthInternalApi
 import com.mmk.kmpauth.core.LaunchingSignInState
+import com.mmk.kmpauth.core.NoOpSignInState
 import com.mmk.kmpauth.core.SignInState
 import com.mmk.kmpauth.core.auth.KMPAuthBackend
 import com.mmk.kmpauth.firebase.backend.FirebaseAuthBackend
@@ -42,6 +44,10 @@ public fun rememberFirebaseGoogleSignInState(
     scopes: List<String> = listOf("email", "profile"),
     onResult: (Result<FirebaseUser?>) -> Unit,
 ): SignInState {
+    // IDE previews never run application startup, so GoogleAuthProvider.create()
+    // has not been called and get() would throw. Render an inert state instead.
+    if (LocalInspectionMode.current) return NoOpSignInState
+
     val googleAuthUiProvider = GoogleAuthProvider.get().getUiProvider()
     val scope = rememberCoroutineScope()
     val currentLinkAccount by rememberUpdatedState(linkAccount)

--- a/kmpauth-core/api/jvm/kmpauth-core.api
+++ b/kmpauth-core/api/jvm/kmpauth-core.api
@@ -12,6 +12,12 @@ public final class com/mmk/kmpauth/core/LaunchingSignInState : com/mmk/kmpauth/c
 	public fun launch ()V
 }
 
+public final class com/mmk/kmpauth/core/NoOpSignInState : com/mmk/kmpauth/core/SignInState {
+	public static final field INSTANCE Lcom/mmk/kmpauth/core/NoOpSignInState;
+	public fun isInProgress ()Z
+	public fun launch ()V
+}
+
 public abstract interface class com/mmk/kmpauth/core/SignInState {
 	public abstract fun isInProgress ()Z
 	public abstract fun launch ()V

--- a/kmpauth-core/api/kmpauth-core.klib.api
+++ b/kmpauth-core/api/kmpauth-core.klib.api
@@ -122,6 +122,13 @@ final object com.mmk.kmpauth.core/KMPAuth { // com.mmk.kmpauth.core/KMPAuth|null
     final fun setLogger(com.mmk.kmpauth.core.logger/KMPAuthLogger) // com.mmk.kmpauth.core/KMPAuth.setLogger|setLogger(com.mmk.kmpauth.core.logger.KMPAuthLogger){}[0]
 }
 
+final object com.mmk.kmpauth.core/NoOpSignInState : com.mmk.kmpauth.core/SignInState { // com.mmk.kmpauth.core/NoOpSignInState|null[0]
+    final val isInProgress // com.mmk.kmpauth.core/NoOpSignInState.isInProgress|{}isInProgress[0]
+        final fun <get-isInProgress>(): kotlin/Boolean // com.mmk.kmpauth.core/NoOpSignInState.isInProgress.<get-isInProgress>|<get-isInProgress>(){}[0]
+
+    final fun launch() // com.mmk.kmpauth.core/NoOpSignInState.launch|launch(){}[0]
+}
+
 final var com.mmk.kmpauth.core.logger/currentLogger // com.mmk.kmpauth.core.logger/currentLogger|{}currentLogger[0]
     final fun <get-currentLogger>(): com.mmk.kmpauth.core.logger/KMPAuthLogger // com.mmk.kmpauth.core.logger/currentLogger.<get-currentLogger>|<get-currentLogger>(){}[0]
     final fun <set-currentLogger>(com.mmk.kmpauth.core.logger/KMPAuthLogger) // com.mmk.kmpauth.core.logger/currentLogger.<set-currentLogger>|<set-currentLogger>(com.mmk.kmpauth.core.logger.KMPAuthLogger){}[0]

--- a/kmpauth-core/src/commonMain/kotlin/com/mmk/kmpauth/core/SignInState.kt
+++ b/kmpauth-core/src/commonMain/kotlin/com/mmk/kmpauth/core/SignInState.kt
@@ -35,6 +35,18 @@ public interface SignInState {
 }
 
 /**
+ * Inert [SignInState] returned while a composable is rendered in inspection
+ * mode (an IDE `@Preview`). Previews never run application startup, so the
+ * provider a real state needs has not been created; returning this instead of
+ * resolving it keeps previews from crashing. [launch] does nothing.
+ */
+@KMPAuthInternalApi
+public object NoOpSignInState : SignInState {
+    override val isInProgress: Boolean = false
+    override fun launch(): Unit = Unit
+}
+
+/**
  * Shared [SignInState] implementation used by the provider modules: runs
  * [block] in [scope], guarding against concurrent launches and driving
  * [isInProgress]. [block] reads its parameters through

--- a/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/NoOpSignInStateTest.kt
+++ b/kmpauth-core/src/commonTest/kotlin/com/mmk/kmpauth/core/NoOpSignInStateTest.kt
@@ -1,0 +1,23 @@
+package com.mmk.kmpauth.core
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+@OptIn(KMPAuthInternalApi::class)
+class NoOpSignInStateTest {
+
+    @Test
+    fun isNeverInProgress() {
+        assertFalse(NoOpSignInState.isInProgress)
+    }
+
+    @Test
+    fun launchDoesNothingAndNeverThrows() {
+        // Previews render real sign-in buttons; clicking one must not blow up
+        // just because application startup never ran.
+        NoOpSignInState.launch()
+        NoOpSignInState.launch()
+
+        assertFalse(NoOpSignInState.isInProgress)
+    }
+}

--- a/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleSignInState.kt
+++ b/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleSignInState.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalInspectionMode
 import com.mmk.kmpauth.core.KMPAuthInternalApi
 import com.mmk.kmpauth.core.LaunchingSignInState
+import com.mmk.kmpauth.core.NoOpSignInState
 import com.mmk.kmpauth.core.SignInState
 import com.mmk.kmpauth.core.logger.currentLogger
 import com.mmk.kmpauth.google.GoogleAuthUiProvider.Companion.BASIC_AUTH_SCOPE
@@ -42,6 +44,10 @@ public fun rememberGoogleSignInState(
     scopes: List<String> = BASIC_AUTH_SCOPE,
     onResult: (GoogleUser?) -> Unit,
 ): SignInState {
+    // IDE previews never run application startup, so GoogleAuthProvider.create()
+    // has not been called and get() would throw. Render an inert state instead.
+    if (LocalInspectionMode.current) return NoOpSignInState
+
     val googleAuthUiProvider = GoogleAuthProvider.get().getUiProvider()
     val scope = rememberCoroutineScope()
     val currentFilter by rememberUpdatedState(filterByAuthorizedAccounts)


### PR DESCRIPTION
Fixes #162.

## Cause

`rememberGoogleSignInState` and `rememberFirebaseGoogleSignInState` both resolved the provider **during composition**:

```kotlin
val googleAuthUiProvider = GoogleAuthProvider.get().getUiProvider()
```

`get()` throws `IllegalArgumentException` when `create()` has not been called, and an IDE `@Preview` never runs application startup — so any preview containing a Google sign-in button failed with:

```
java.lang.IllegalArgumentException: Make sure you invoked GoogleAuthProvider #create method with providing credentials
```

## Fix

Return an inert `SignInState` when `LocalInspectionMode` is true, before touching the provider. Previews render the button; `launch()` does nothing.

## Why here rather than in the container

#178 proposed patching `GoogleButtonUiContainer`. That location is no longer sufficient: in 3.0 the deprecated containers are **thin wrappers over these states**, so fixing only the container would leave previews of the current `rememberXxxSignInState` API broken. Guarding inside the state functions fixes both the new API and the 2.x containers in one place — and covers the Firebase variant, which had the identical bug.

The inert state lives in `kmpauth-core` as `NoOpSignInState` so the provider and Firebase modules share one implementation.

## Verification

`apiCheck`, `jvmTest` and `testAndroid` green; API dumps regenerated for the new `NoOpSignInState`. Added a small test locking its contract (never in progress, `launch()` never throws).

⚠️ The guard itself is verified by compilation and reasoning, not by running an actual IDE preview — worth a quick `@Preview` check in Android Studio when convenient.

Should let #178 be closed as superseded.