### PR TITLE
fix(google): ship consumer R8 rules so release builds keep working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Google Sign-In now works in minified release builds** (#144). `kmpauth-google`
+  ships consumer R8/ProGuard rules, so apps no longer need to add keep rules of
+  their own. Credential Manager resolves its Play services provider
+  reflectively; R8 stripped it in release builds, which is why sign-in worked in
+  debug and silently did nothing once minified. Any module can now ship rules by
+  placing a `consumer-rules.pro` next to its build file — the convention plugin
+  publishes it with the artifact.
 - **Google sign-in composables no longer crash IDE previews** (#162).
   `rememberGoogleSignInState` and `rememberFirebaseGoogleSignInState` resolved
   the provider during composition via `GoogleAuthProvider.get()`, which throws

--- a/build-logic/convention/src/main/kotlin/kmpauth.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/kmpauth.kmp.library.gradle.kts
@@ -42,6 +42,17 @@ kotlin {
 
         withHostTest { }
 
+        // A module ships consumer R8 rules by dropping a consumer-rules.pro
+        // next to its build file; they are then published with the artifact so
+        // apps do not have to copy them into their own configuration.
+        val consumerRules = project.file("consumer-rules.pro")
+        if (consumerRules.exists()) {
+            optimization {
+                consumerKeepRules.file(consumerRules)
+                consumerKeepRules.publish = true
+            }
+        }
+
         packaging {
             resources {
                 excludes.add("/META-INF/AL2.0")

--- a/providers/kmpauth-google/consumer-rules.pro
+++ b/providers/kmpauth-google/consumer-rules.pro
@@ -1,0 +1,13 @@
+# Consumer R8/ProGuard rules shipped with kmpauth-google.
+#
+# Credential Manager loads its Google Play services provider reflectively, so
+# R8 strips it in release builds unless it is kept. Without this, Google
+# Sign-In silently does nothing in a minified build while working fine in debug.
+# See https://developer.android.com/identity/sign-in/credential-manager
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}
+
+# The Google ID token credential is constructed from a Bundle by name.
+-keep class com.google.android.libraries.identity.googleid.** { *; }


### PR DESCRIPTION
Fixes #144.

## Problem

Google Sign-In worked in debug but silently did nothing in minified release builds. Credential Manager resolves its Play services provider **reflectively**, so R8 strips `androidx.credentials.playservices` unless it is explicitly kept — and the failure surfaces only as a `CredManProvService` log line, exactly what the reporter saw.

KMPAuth shipped **no consumer rules at all** (verified: no `consumer-rules.pro` anywhere in the repo), so every consumer had to discover and copy the keep rules themselves.

## Fix

Ship them with the artifact:

```
-if class androidx.credentials.CredentialManager
-keep class androidx.credentials.playservices.** { *; }

-keep class com.google.android.libraries.identity.googleid.** { *; }
```

The convention plugin publishes a module's `consumer-rules.pro` via AGP's `optimization.consumerKeepRules` (`publish = true`), so **any** module can ship rules by dropping the file next to its build file — `kmpauth-google` is just the first to need it.

## Verified in the built artifact

Not just "it compiles" — the rules actually reach consumers:

```
$ unzip -l providers/kmpauth-google/build/outputs/aar/kmpauth-google.aar | grep proguard
      612  proguard.txt

$ unzip -p .../kmpauth-google.aar proguard.txt
-if class androidx.credentials.CredentialManager
-keep class androidx.credentials.playservices.** { *; }
...
```

`apiCheck` and `jvmTest` green. No API change.

⚠️ Not verified by actually running a minified release build end-to-end — the rules are the documented ones from the [Credential Manager guide](https://developer.android.com/identity/sign-in/credential-manager) and are confirmed present in the artifact, but a real `minifyEnabled true` sign-in would be the conclusive check.