### PR TITLE
fix(build): enable Android resources so composeResources ship to consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to KMPAuth are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Compose resources are packaged again on Android.** `kmpauth-uihelper`'s icons
+  and font never reached consuming apps, so every sign-in button crashed at
+  runtime with
+  `MissingResourceException: Missing resource with path: composeResources/…`.
+  AGP 9's KMP library plugin disables Android resources by default, and Compose
+  Multiplatform resources ship as Android assets, so the modules generated their
+  `composeResources` but published none of them. The convention plugin now sets
+  `androidResources { enable = true }`.
+
 ## [3.0.0-alpha03] — 2026-07-19
 
 ### Changed

--- a/build-logic/convention/src/main/kotlin/kmpauth.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/kmpauth.kmp.library.gradle.kts
@@ -40,6 +40,14 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
 
+        // AGP 9's KMP library plugin disables Android resources by default.
+        // Compose Multiplatform resources are packaged as Android assets, so
+        // without this a module builds its composeResources but ships none, and
+        // consumers crash at runtime with MissingResourceException.
+        androidResources {
+            enable = true
+        }
+
         withHostTest { }
 
         // A module ships consumer R8 rules by dropping a consumer-rules.pro


### PR DESCRIPTION
## Symptom

Every `kmpauth-uihelper` sign-in button crashed on first composition in a consuming Android app:

```
org.jetbrains.compose.resources.MissingResourceException: Missing resource with path:
composeResources/io.github.mirzemehdi.kmpauth_uihelper.generated.resources/drawable/ic_google.xml
```

## Cause

AGP 9's `com.android.kotlin.multiplatform.library` **disables Android resources by default**, and Compose Multiplatform resources are packaged as Android **assets**. So the modules generated their `composeResources` — they're sitting in `build/generated/assets/copyDebugComposeResourcesToAndroidAssets/…` — but published none of them.

The sample APK contained **zero asset entries**:

```
$ unzip -l androidApp-debug.apk | grep -c "assets/"
0
```

This is the documented AGP 9 gotcha: *"Compose resources crash without `androidResources { enable = true }`"*.

## Fix

Set it in the convention plugin, so every library module packages its resources rather than each one having to remember:

```kotlin
androidResources {
    enable = true
}
```

## Verification

Built the sample APK and inspected it — all six uihelper resources are now packaged, including the `ic_google.xml` from the crash:

```
assets/composeResources/io.github.mirzemehdi.kmpauth_uihelper.generated.resources/drawable/ic_apple_logo_black.xml
assets/composeResources/…/drawable/ic_apple_logo_white.xml
assets/composeResources/…/drawable/ic_facebook_logo_background_white.xml
assets/composeResources/…/drawable/ic_facebook_logo_blue.xml
assets/composeResources/…/drawable/ic_google.xml
assets/composeResources/…/font/roboto_medium.ttf
```

Confirmed on **both AGP 9.3.0 and 9.2.1**. `apiCheck`, `jvmTest` and `testAndroid` green.

## Note

This has been broken since the AGP 9 migration, so **alpha01–alpha03 all ship it** — any Android app using the `kmpauth-uihelper` buttons crashes. Worth an alpha04 shortly after this merges.

It also explains why CI never caught it: CI builds the sample APK but never runs it, and the failure is at runtime.