### PR TITLE
chore(build): pin AGP to 9.2.1 for Android Studio compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Dependency updates: Gradle 9.4.1 → **9.6.1**, Android Gradle Plugin 9.2.0 →
-  **9.3.0** (requires Gradle 9.5+), `play-services-auth` 21.4.0 → **21.6.0**,
+  **9.2.1** (9.3.0 was tried but needs a newer Android Studio than the project
+  targets), `play-services-auth` 21.4.0 → **21.6.0**,
   `google-services` 4.4.4 → **4.5.0**, `java-jwt` 4.5.2 → **4.6.0**. Kotlin,
   Compose Multiplatform, Ktor, GitLive Firebase, Firebase BoM, the Facebook SDK,
   `androidx.credentials` and `googleid` were already on their latest stable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compose = "1.11.4"
 compose-plugin = "1.11.1"
-agp = "9.3.0"
+agp = "9.2.1"
 android-minSdk = "24"
 android-compileSdk = "37"
 android-targetSdk = "36"


### PR DESCRIPTION
AGP **9.3.0**, picked up in the alpha02 dependency refresh, is newer than the Android Studio version this project targets, so the project no longer syncs cleanly in the IDE. Pin to **9.2.1** — the latest AGP the current tooling supports — until Android Studio catches up.

**Gradle stays at 9.6.1.** It was only raised because AGP 9.3.0 required Gradle 9.5+; 9.2.1 builds fine on 9.6.1, and 9.6.1 is current stable, so there's no reason to move it back.

Also corrects the alpha02 CHANGELOG entry, which claimed 9.3.0.

## Verification

`apiCheck`, `jvmTest`, `testAndroid` and `:sampleApp:androidApp:assembleDebug` all green on 9.2.1.

Note the compose-resources packaging fix in #210 was verified on **both** 9.3.0 and 9.2.1, so the two changes are independent — that bug was AGP-9-wide, not specific to either patch version.