### PR TITLE
feat(sample): wire the Supabase backend into the sample app

### DIFF
--- a/backends/supabase/kmpauth-supabase/build.gradle.kts
+++ b/backends/supabase/kmpauth-supabase/build.gradle.kts
@@ -23,6 +23,8 @@ kotlin {
         }
 
         jvmTest.dependencies {
+            // Real engine for the @Ignore-d manual live harness.
+            implementation(libs.ktor.client.cio)
             implementation(libs.kotlinx.coroutines.test)
             // Test-only Ktor MockEngine to exercise the backend against
             // canned GoTrue responses without network. Never shipped.

--- a/backends/supabase/kmpauth-supabase/src/jvmTest/kotlin/com/mmk/kmpauth/supabase/ManualSupabaseE2ETest.kt
+++ b/backends/supabase/kmpauth-supabase/src/jvmTest/kotlin/com/mmk/kmpauth/supabase/ManualSupabaseE2ETest.kt
@@ -1,0 +1,37 @@
+package com.mmk.kmpauth.supabase
+
+// Manual live harness against the sample's real Supabase project - @Ignore-d
+// because it does network calls; remove @Ignore to run.
+
+import com.mmk.kmpauth.core.auth.AuthCredential
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.createSupabaseClient
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+class ManualSupabaseE2ETest {
+
+    @Test
+    @Ignore
+    fun liveSupabaseE2E(): Unit = runBlocking {
+        val client = createSupabaseClient(
+            supabaseUrl = "https://mlhefwyzasscsqjqtvhk.supabase.co",
+            supabaseKey = "sb_publishable_dCWSZWxJqYcdsi6Hm0gXcQ_aeM91-z2",
+        ) { install(Auth) }
+        val backend = SupabaseAuthBackend(client)
+
+        val anon = backend.signInAnonymously()
+        println("SB_ANON=${anon.map { "${it.uid} anonymous-ok" }}")
+        println("SB_CURRENT=${backend.currentUser()?.uid}")
+        backend.signOut()
+
+        val signUp = backend.signUp("kmpauth-e2e-test@example.com", "Str0ngPass!e2e")
+        println("SB_SIGNUP=${signUp.map { "${it.uid} email=${it.email}" }}")
+
+        val badLogin = backend.signIn(
+            AuthCredential.EmailPassword("nonexistent-e2e@example.com", "wrong-pass-123")
+        )
+        println("SB_BADLOGIN=${badLogin.exceptionOrNull()?.message ?: badLogin}")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ androidLegacyPlayServices = "21.6.0"
 mavenPublish = "0.37.0"
 kotlinx-coroutines = "1.11.0"
 supabase = "3.7.0"
-ktor = "3.5.1" # test-only (MockEngine); keep on the Ktor generation supabase-kt ships
+ktor = "3.5.1" # sampleApp engines + test-only MockEngine; keep on the Ktor generation supabase-kt ships
 
 
 [libraries]
@@ -77,6 +77,9 @@ firebase-android-bom = { module = "com.google.firebase:firebase-bom", version.re
 #Supabase
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 
 #Facebook
 facebookAuthAndroid= { module = "com.facebook.android:facebook-login", version.ref = "facebookAuthAndroid" }

--- a/sampleApp/shared/build.gradle.kts
+++ b/sampleApp/shared/build.gradle.kts
@@ -49,6 +49,8 @@ kotlin {
         val desktopMain by getting
 
         androidMain.dependencies {
+            // Ktor engine for supabase-kt.
+            implementation(libs.ktor.client.cio)
             implementation(libs.compose.ui)
             implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.activity.compose)
@@ -65,10 +67,26 @@ kotlin {
             implementation(project(":backends:firebase:kmpauth-firebase-core"))
             implementation(project(":backends:firebase:kmpauth-firebase-google"))
             implementation(project(":backends:firebase:kmpauth-firebase-facebook"))
+            // Supabase backend demo (see AppInitializer.USE_SUPABASE_BACKEND).
+            implementation(project(":backends:supabase:kmpauth-supabase"))
             implementation(project(":kmpauth-uihelper"))
         }
         desktopMain.dependencies {
             implementation(compose.desktop.common)
+            // Ktor engine for supabase-kt.
+            implementation(libs.ktor.client.cio)
+        }
+        iosMain.dependencies {
+            // Ktor engine for supabase-kt.
+            implementation(libs.ktor.client.darwin)
+        }
+        jsMain.dependencies {
+            // Ktor engine for supabase-kt.
+            implementation(libs.ktor.client.js)
+        }
+        wasmJsMain.dependencies {
+            // Ktor engine for supabase-kt.
+            implementation(libs.ktor.client.js)
         }
     }
 }

--- a/sampleApp/shared/src/commonMain/kotlin/com/mmk/kmpauth/sample/AppInitializer.kt
+++ b/sampleApp/shared/src/commonMain/kotlin/com/mmk/kmpauth/sample/AppInitializer.kt
@@ -5,7 +5,16 @@ import com.mmk.kmpauth.firebase.FirebaseBackendOptions
 import com.mmk.kmpauth.firebase.firebase
 import com.mmk.kmpauth.google.GoogleAuthCredentials
 import com.mmk.kmpauth.google.google
+import com.mmk.kmpauth.supabase.SupabaseBackendOptions
+import com.mmk.kmpauth.supabase.supabase
 
+/**
+ * Flip to true to serve every `rememberXxxAuthState` flow and `KMPAuth.*`
+ * operation from Supabase instead of Firebase — nothing else in the app
+ * changes. (Web-flow providers — GitHub/Microsoft/Apple-on-Android — stay
+ * Firebase-driven; the Supabase backend reports them as unsupported.)
+ */
+private const val USE_SUPABASE_BACKEND = false
 
 object AppInitializer {
     fun onApplicationStart() {
@@ -23,6 +32,17 @@ object AppInitializer {
                     applicationId = "1:180951249266:android:1a83eb8eea4835070e2deb",
                 )
             )
+            if (USE_SUPABASE_BACKEND) {
+                // replace = true because the Firebase backend registers
+                // eagerly at load on iOS/JS/wasm.
+                supabase(
+                    SupabaseBackendOptions(
+                        url = "https://mlhefwyzasscsqjqtvhk.supabase.co",
+                        apiKey = "sb_publishable_dCWSZWxJqYcdsi6Hm0gXcQ_aeM91-z2",
+                    ),
+                    replace = true,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #215: wires the Supabase backend into the sample app.

- `USE_SUPABASE_BACKEND` flag in `AppInitializer` — one boolean flips every `rememberXxxAuthState` flow and `KMPAuth.*` operation from Firebase to the real Supabase project (`replace = true` because Firebase registers eagerly at load on iOS/JS/wasm).
- Per-platform Ktor engines added to the **sample only** (CIO android/desktop, Darwin iOS, Js web) — library modules stay Ktor-free.
- Verified live: real GoTrue error codes round-trip through the backend as failure `Result`s (`anonymous_provider_disabled` — enable the provider in the dashboard for full anonymous testing, `email_address_invalid`, `invalid_credentials`). Manual harness kept as an `@Ignore`d jvmTest.
- All targets compile; apiCheck/jvmTest/testAndroid green.
