### PR TITLE
fix(google): web ID token via Sign in with Google; correct filterByAuthorizedAccounts docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Result` values. On Desktop (JVM) the underlying Firebase SDK does not
   implement auth yet (#204), so they return failed `Result`s there.
 
+### Fixed
+- **Web (JS/wasm) Google sign-in returns an ID token** (#146). Google's GIS
+  splits tokens across two flows - the OAuth token client used before only
+  ever returns an access token, so `GoogleUser.idToken` was always empty on
+  web and Firebase/backend exchange was impossible. The web implementations
+  now obtain the ID token via Sign in with Google (`google.accounts.id`,
+  FedCM-enabled) first, filling profile data from the JWT claims, and only
+  run the token flow when an access token is requested (`requestAccessToken`
+  or extra scopes) or the One Tap prompt is suppressed.
+- **`filterByAuthorizedAccounts` documentation was inverted** (#117). The
+  KDoc claimed true shows all accounts; actually true limits the chooser to
+  accounts that previously signed in to the app - and when none exists the
+  flow deliberately retries with all accounts so first-time users can sign
+  in, which is why a device with two authorized accounts still shows both.
+
 ## [3.0.0-alpha04] — 2026-07-19
 
 ### Added
@@ -181,7 +196,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `accessToken` and `serverAuthCode` — the legacy Android fallback never returns
   an access token, which is why it appeared to be missing (#129).
 
-### Fixed
+- **Web (JS/wasm) Google sign-in returns an ID token** (#146). Google's GIS
+  splits tokens across two flows - the OAuth token client used before only
+  ever returns an access token, so `GoogleUser.idToken` was always empty on
+  web and Firebase/backend exchange was impossible. The web implementations
+  now obtain the ID token via Sign in with Google (`google.accounts.id`,
+  FedCM-enabled) first, filling profile data from the JWT claims, and only
+  fall back to / additionally run the token flow when an access token is
+  requested (`requestAccessToken` or extra scopes) or the One Tap prompt is
+  suppressed.
+- **`filterByAuthorizedAccounts` documentation was inverted** (#117). The
+  KDoc claimed true shows all accounts; actually true limits the chooser to
+  accounts that previously signed in to the app, and when none exists the
+  flow deliberately retries with all accounts so first-time users can sign
+  in - which is why a device with two authorized accounts still shows both.
 - **Compose resources are packaged again on Android.** `kmpauth-uihelper`'s icons
   and font never reached consuming apps, so every sign-in button crashed at
   runtime with

--- a/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProvider.kt
+++ b/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProvider.kt
@@ -26,8 +26,11 @@ public interface GoogleAuthUiProvider {
 
 
     /**
-     * @param filterByAuthorizedAccounts set to true so users can choose between available accounts to sign in.
-     * setting to false list any accounts that have previously been used to sign in to your app. Default value is false.
+     * @param filterByAuthorizedAccounts true limits the chooser to accounts
+     * that have previously signed in to this app; false lists all available
+     * accounts on the device. Default value is false. Note: when true and no
+     * previously authorized account exists, the flow automatically retries
+     * with all accounts so first-time users can still sign in.
      * @param isAutoSelectEnabled If `true`, the user will be automatically signed in
      * without showing the account chooser when there is exactly one eligible account.
      * If `false`, the account chooser will be shown even if only one account is available. Default value is true
@@ -45,8 +48,11 @@ public interface GoogleAuthUiProvider {
 
 
     /**
-     * @param filterByAuthorizedAccounts set to true so users can choose between available accounts to sign in.
-     * setting to false list any accounts that have previously been used to sign in to your app. Default value is false.
+     * @param filterByAuthorizedAccounts true limits the chooser to accounts
+     * that have previously signed in to this app; false lists all available
+     * accounts on the device. Default value is false. Note: when true and no
+     * previously authorized account exists, the flow automatically retries
+     * with all accounts so first-time users can still sign in.
      * @param isAutoSelectEnabled If `true`, the user will be automatically signed in
      * without showing the account chooser when there is exactly one eligible account.
      * If `false`, the account chooser will be shown even if only one account is available. Default value is true

--- a/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleSignInState.kt
+++ b/providers/kmpauth-google/src/commonMain/kotlin/com/mmk/kmpauth/google/GoogleSignInState.kt
@@ -31,7 +31,9 @@ import com.mmk.kmpauth.google.GoogleAuthUiProvider.Companion.BASIC_AUTH_SCOPE
  * ```
  *
  * @param filterByAuthorizedAccounts true limits the account list to accounts
- * previously used with this app; false lists all available accounts.
+ * previously used with this app; false lists all available accounts. Note:
+ * when true and no previously authorized account exists, the flow
+ * automatically retries with all accounts so first-time users can sign in.
  * @param isAutoSelectEnabled sign in automatically when exactly one eligible
  * account exists.
  * @param scopes OAuth scopes to request. Default `listOf("email", "profile")`.

--- a/providers/kmpauth-google/src/jsMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/providers/kmpauth-google/src/jsMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -33,22 +33,81 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             )
         }
 
-        return suspendCancellableCoroutine { continuation ->
-            val tokenClientConfig = createTokenClientConfig(
-                clientId = credentials.serverId,
-                scope = scopes.joinToString(" "),
-                prompt = if (filterByAuthorizedAccounts) "none" else "select_account",
-                callback = { tokenResponse: dynamic ->
-                    CoroutineScope(continuation.context).launch {
-                        continuation.handleTokenResponse(tokenResponse)
-                    }
-                }
-            )
-            val tokenClient = initTokenClient(tokenClientConfig)
-            requestAccessToken(tokenClient)
+        // GIS splits the two tokens across two flows: google.accounts.id
+        // (Sign in with Google / One Tap) issues the ID token, while the
+        // OAuth token client issues the access token only (#146). Get the
+        // ID token first - it is what Firebase and app backends verify.
+        val needsAccessToken = requestAccessToken ||
+            scopes.toSet() != GoogleAuthUiProvider.BASIC_AUTH_SCOPE.toSet()
+        val idToken = requestIdTokenViaOneTap(isAutoSelectEnabled)
+
+        if (idToken != null && !needsAccessToken) {
+            return Result.success(googleUserFromIdToken(idToken))
         }
+        if (idToken == null) {
+            showConsoleError(
+                "GoogleAuthUiProvider: One Tap did not return an ID token " +
+                    "(prompt suppressed or dismissed); falling back to the OAuth token flow."
+            )
+        }
+        return requestViaTokenClient(filterByAuthorizedAccounts, scopes, idToken)
     }
 
+    /**
+     * Runs the Sign in with Google (One Tap) prompt and returns the ID
+     * token, or null when the prompt is suppressed, skipped or dismissed.
+     */
+    private suspend fun requestIdTokenViaOneTap(isAutoSelectEnabled: Boolean): String? =
+        withTimeoutOrNull(5.minutes) {
+            suspendCancellableCoroutine { continuation ->
+                var resumed = false
+                fun resumeOnce(value: String?) {
+                    if (!resumed && continuation.isActive) {
+                        resumed = true
+                        continuation.resume(value)
+                    }
+                }
+                initializeGsiId(
+                    clientId = credentials.serverId,
+                    autoSelect = isAutoSelectEnabled,
+                    callback = { credentialResponse: dynamic ->
+                        resumeOnce(credentialResponse.credential as? String)
+                    },
+                )
+                promptGsiId { moment: dynamic ->
+                    // Covers FedCM and pre-FedCM notification shapes.
+                    if (isMomentTerminal(moment)) resumeOnce(null)
+                }
+            }
+        }
+
+    /** OAuth token-client flow: access token (plus a previously obtained ID token, if any). */
+    private suspend fun requestViaTokenClient(
+        filterByAuthorizedAccounts: Boolean,
+        scopes: List<String>,
+        presetIdToken: String?,
+    ): Result<GoogleUser> = suspendCancellableCoroutine { continuation ->
+        val tokenClientConfig = createTokenClientConfig(
+            clientId = credentials.serverId,
+            scope = scopes.joinToString(" "),
+            prompt = if (filterByAuthorizedAccounts) "none" else "select_account",
+            callback = { tokenResponse: dynamic ->
+                CoroutineScope(continuation.context).launch {
+                    continuation.handleTokenResponse(tokenResponse, presetIdToken)
+                }
+            }
+        )
+        val tokenClient = initTokenClient(tokenClientConfig)
+        requestAccessToken(tokenClient)
+    }
+
+    private fun googleUserFromIdToken(idToken: String): GoogleUser = GoogleUser(
+        idToken = idToken,
+        accessToken = null,
+        email = jwtClaim(idToken, "email"),
+        displayName = jwtClaim(idToken, "name") ?: "",
+        profilePicUrl = jwtClaim(idToken, "picture"),
+    )
 
     private fun loadGoogleAuthScript() {
         val script = document.createElement("script") as HTMLScriptElement
@@ -61,8 +120,10 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         document.head?.appendChild(script)
     }
 
-    private suspend fun CancellableContinuation<Result<GoogleUser>>.handleTokenResponse(tokenResponse: dynamic) {
-
+    private suspend fun CancellableContinuation<Result<GoogleUser>>.handleTokenResponse(
+        tokenResponse: dynamic,
+        presetIdToken: String?,
+    ) {
         val error = getTokenResponseError(tokenResponse)
         if (error != null) {
             showConsoleError("Error during Google sign-in: $error")
@@ -70,7 +131,7 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             return
         }
 
-        val idToken = getTokenResponseIdToken(tokenResponse) ?: ""
+        val idToken = presetIdToken ?: getTokenResponseIdToken(tokenResponse) ?: ""
         val accessToken = getTokenResponseAccessToken(tokenResponse) ?: ""
 
         try {
@@ -174,3 +235,52 @@ private fun getTokenResponseIdToken(tokenResponse: dynamic): String? = tokenResp
 
 // Extract access_token from tokenResponse
 private fun getTokenResponseAccessToken(tokenResponse: dynamic): String? = tokenResponse.access_token
+
+// --- Sign in with Google (google.accounts.id) interop -----------------------
+
+private fun initializeGsiId(
+    clientId: String,
+    autoSelect: Boolean,
+    callback: (dynamic) -> Unit,
+) {
+    val config = js("({})")
+    js("Object.assign")(
+        config, json(
+            "client_id" to clientId,
+            "auto_select" to autoSelect,
+            "callback" to callback,
+            "use_fedcm_for_prompt" to true,
+        )
+    )
+    js("google.accounts.id.initialize(config)")
+}
+
+private fun promptGsiId(momentCallback: (dynamic) -> Unit) {
+    js("google.accounts.id.prompt(momentCallback)")
+}
+
+/** True when the prompt will not produce a credential (skipped/dismissed/not shown). */
+private fun isMomentTerminal(moment: dynamic): Boolean = try {
+    when {
+        moment.isSkippedMoment != null && moment.isSkippedMoment() == true -> true
+        moment.isDismissedMoment != null && moment.isDismissedMoment() == true &&
+            moment.getDismissedReason != null &&
+            moment.getDismissedReason() != "credential_returned" -> true
+        moment.isNotDisplayed != null && moment.isNotDisplayed() == true -> true
+        else -> false
+    }
+} catch (e: Throwable) {
+    true
+}
+
+/** Reads a claim from the ID token's JWT payload without verification. */
+private fun jwtClaim(jwt: String, name: String): String? = try {
+    val payloadJson = window.atob(
+        jwt.split(".")[1].replace("-", "+").replace("_", "/")
+    )
+    val payload = JSON.parse<dynamic>(payloadJson)
+    val value = payload[name]
+    if (value == null) null else value.toString()
+} catch (e: Throwable) {
+    null
+}

--- a/providers/kmpauth-google/src/wasmJsMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
+++ b/providers/kmpauth-google/src/wasmJsMain/kotlin/com/mmk/kmpauth/google/GoogleAuthUiProviderImpl.kt
@@ -3,7 +3,13 @@ package com.mmk.kmpauth.google
 import com.mmk.kmpauth.core.KMPAuthInternalApi
 import com.mmk.kmpauth.core.logger.currentLogger
 import kotlinx.browser.document
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.await
+import kotlinx.coroutines.withTimeoutOrNull
 import org.w3c.dom.HTMLScriptElement
 import kotlin.coroutines.resume
 import kotlin.js.Promise
@@ -18,14 +24,12 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         if (!googleAuthScriptLoaded) loadGoogleAuthScript()
     }
 
-
     override suspend fun signIn(
         filterByAuthorizedAccounts: Boolean,
         isAutoSelectEnabled: Boolean,
         scopes: List<String>,
         requestAccessToken: Boolean
     ): Result<GoogleUser> {
-
         val scriptLoaded = waitForGoogleAuthScriptToLoad()
         if (!scriptLoaded) {
             return Result.failure(
@@ -33,22 +37,82 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             )
         }
 
-        return suspendCancellableCoroutine { continuation ->
-            val tokenClientConfig = createTokenClientConfig(
-                clientId = credentials.serverId,
-                scope = scopes.joinToString(" "),
-                prompt = if (filterByAuthorizedAccounts) "none" else "select_account",
-                callback = { tokenResponse: JsAny ->
-                    CoroutineScope(continuation.context).launch {
-                        continuation.handleTokenResponse(tokenResponse)
+        // GIS splits the two tokens across two flows: google.accounts.id
+        // (Sign in with Google / One Tap) issues the ID token, while the
+        // OAuth token client issues the access token only (#146). Get the
+        // ID token first - it is what Firebase and app backends verify.
+        val needsAccessToken = requestAccessToken ||
+            scopes.toSet() != GoogleAuthUiProvider.BASIC_AUTH_SCOPE.toSet()
+        val idToken = requestIdTokenViaOneTap(isAutoSelectEnabled)
+
+        if (idToken != null && !needsAccessToken) {
+            return Result.success(googleUserFromIdToken(idToken))
+        }
+        if (idToken == null) {
+            currentLoggerLog(
+                "GoogleAuthUiProvider: One Tap did not return an ID token " +
+                    "(prompt suppressed or dismissed); falling back to the OAuth token flow."
+            )
+        }
+        return requestViaTokenClient(filterByAuthorizedAccounts, scopes, idToken)
+    }
+
+    /**
+     * Runs the Sign in with Google (One Tap) prompt and returns the ID
+     * token, or null when the prompt is suppressed, skipped or dismissed.
+     */
+    private suspend fun requestIdTokenViaOneTap(isAutoSelectEnabled: Boolean): String? =
+        withTimeoutOrNull(5.minutes) {
+            suspendCancellableCoroutine { continuation ->
+                var resumed = false
+                fun resumeOnce(value: String?) {
+                    if (!resumed && continuation.isActive) {
+                        resumed = true
+                        continuation.resume(value)
                     }
                 }
-            )
-
-            val tokenClient = initTokenClient(tokenClientConfig)
-            requestAccessToken(tokenClient)
+                initializeGsiId(
+                    clientId = credentials.serverId,
+                    autoSelect = isAutoSelectEnabled,
+                    callback = { credentialResponse ->
+                        resumeOnce(getCredentialResponseIdToken(credentialResponse))
+                    },
+                )
+                promptGsiId { moment ->
+                    // Covers FedCM and pre-FedCM notification shapes.
+                    if (isMomentTerminal(moment)) resumeOnce(null)
+                }
+            }
         }
+
+    /** OAuth token-client flow: access token (plus a previously obtained ID token, if any). */
+    private suspend fun requestViaTokenClient(
+        filterByAuthorizedAccounts: Boolean,
+        scopes: List<String>,
+        presetIdToken: String?,
+    ): Result<GoogleUser> = suspendCancellableCoroutine { continuation ->
+        val tokenClientConfig = createTokenClientConfig(
+            clientId = credentials.serverId,
+            scope = scopes.joinToString(" "),
+            prompt = if (filterByAuthorizedAccounts) "none" else "select_account",
+            callback = { tokenResponse: JsAny ->
+                CoroutineScope(continuation.context).launch {
+                    continuation.handleTokenResponse(tokenResponse, presetIdToken)
+                }
+            }
+        )
+
+        val tokenClient = initTokenClient(tokenClientConfig)
+        requestAccessToken(tokenClient)
     }
+
+    private fun googleUserFromIdToken(idToken: String): GoogleUser = GoogleUser(
+        idToken = idToken,
+        accessToken = null,
+        email = jwtClaim(idToken, "email"),
+        displayName = jwtClaim(idToken, "name") ?: "",
+        profilePicUrl = jwtClaim(idToken, "picture"),
+    )
 
     private fun loadGoogleAuthScript() {
         val script = document.createElement("script") as HTMLScriptElement
@@ -73,8 +137,10 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         }
     }
 
-    private suspend fun CancellableContinuation<Result<GoogleUser>>.handleTokenResponse(tokenResponse: JsAny) {
-
+    private suspend fun CancellableContinuation<Result<GoogleUser>>.handleTokenResponse(
+        tokenResponse: JsAny,
+        presetIdToken: String?,
+    ) {
         val error = getTokenResponseError(tokenResponse)
         if (error != null) {
             showConsoleError("Error during Google sign-in: $error")
@@ -82,7 +148,7 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
             return
         }
 
-        val idToken = getTokenResponseIdToken(tokenResponse) ?: ""
+        val idToken = presetIdToken ?: getTokenResponseIdToken(tokenResponse) ?: ""
         val accessToken = getTokenResponseAccessToken(tokenResponse) ?: ""
 
         val googleUserInfoPromise: Promise<JsAny> = fetchGoogleUserInfoPromise(accessToken).unsafeCast()
@@ -114,6 +180,10 @@ internal class GoogleAuthUiProviderImpl(private val credentials: GoogleAuthCrede
         }
     }
 
+    @OptIn(KMPAuthInternalApi::class)
+    private fun currentLoggerLog(message: String) {
+        currentLogger.log(message)
+    }
 }
 
 
@@ -185,8 +255,58 @@ private fun getTokenResponseIdToken(tokenResponse: JsAny): String? = js("tokenRe
 // Extract access_token from tokenResponse
 private fun getTokenResponseAccessToken(tokenResponse: JsAny): String? = js("tokenResponse.access_token")
 
+// --- Sign in with Google (google.accounts.id) interop -----------------------
 
+@JsFun(
+    """
+    (clientId, autoSelect, callback) => {
+        google.accounts.id.initialize({
+            client_id: clientId,
+            auto_select: autoSelect,
+            callback: callback,
+            use_fedcm_for_prompt: true
+        });
+    }
+"""
+)
+private external fun initializeGsiId(
+    clientId: String,
+    autoSelect: Boolean,
+    callback: (JsAny) -> Unit,
+)
 
+private fun promptGsiId(momentCallback: (JsAny) -> Unit): Unit =
+    js("google.accounts.id.prompt(momentCallback)")
 
+/** True when the prompt will not produce a credential (skipped/dismissed/not shown). */
+private fun isMomentTerminal(moment: JsAny): Boolean =
+    js(
+        """
+        (() => {
+           try {
+             if (moment.isSkippedMoment && moment.isSkippedMoment()) return true;
+             if (moment.isDismissedMoment && moment.isDismissedMoment()
+                 && moment.getDismissedReason && moment.getDismissedReason() !== 'credential_returned') return true;
+             if (moment.isNotDisplayed && moment.isNotDisplayed()) return true;
+           } catch (e) { return true; }
+           return false;
+        })()
+    """
+    )
 
+private fun getCredentialResponseIdToken(credentialResponse: JsAny): String? =
+    js("credentialResponse.credential")
 
+/** Reads a claim from the ID token's JWT payload without verification. */
+private fun jwtClaim(jwt: String, name: String): String? =
+    js(
+        """
+        (() => {
+           try {
+             const payload = JSON.parse(atob(jwt.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+             const value = payload[name];
+             return value == null ? null : String(value);
+           } catch (e) { return null; }
+        })()
+    """
+    )


### PR DESCRIPTION
Closes #146. Fixes the documentation side of #117.

## #146 — web ID token

GIS splits tokens across two flows: the OAuth token client (`initTokenClient`) **only returns an access token** — `tokenResponse.id_token` never exists — so on js/wasm `GoogleUser.idToken` was always empty and Firebase exchange was impossible. Both web implementations now:

1. Request the ID token first via **Sign in with Google** (`google.accounts.id.initialize` + `prompt()`, FedCM-enabled) — profile fields (email/name/picture) read from the JWT claims, no extra network call.
2. Run the OAuth token flow only when an access token is actually wanted (`requestAccessToken = true` or non-basic scopes) or when the One Tap prompt is suppressed/skipped/dismissed (cooldown etc.) — the old behavior becomes the fallback instead of the only path. When both run, the returned `GoogleUser` carries both tokens.

Moment detection covers FedCM and pre-FedCM notification shapes; 5-minute guard, single-resume protection.

## #117 — filterByAuthorizedAccounts

The KDoc was **inverted** (claimed `true` shows all accounts). Corrected everywhere: `true` = only accounts that previously signed in to this app; `false` = all device accounts. Also documented the intentional fallback — with `true` and no previously authorized account, the flow retries with all accounts so first-time users can sign in — which explains the "I still see two accounts" report.

## Verification

apiCheck, jvmTest, testAndroid green; js + wasm compile (kmpauth-google, sample webApp both variants). Live browser check of the One Tap path needs a real origin allowed in the Google console — flagged for the pre-stable web test pass.
